### PR TITLE
Solving https://github.com/pytroll/pyorbital/issues/6

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -90,7 +90,12 @@ class TLETest(unittest.TestCase):
         finally:
             remove(filename)
 
-
+    def test_positive_sign_tle(self):
+        #See issue https://github.com/pytroll/pyorbital/issues/6
+        line1 = "1 25544U 98067A   15235.81765006 +.00009573 +00000-0 +14486-3 0  9999"
+        line2 = "2 25544 051.6452 106.3529 0001648 090.4174 004.9123 15.55401685958567"
+        tle = Tle("ISS (ZARYA)", line1=line1, line2=line2)
+        
 def suite():
     """The suite for test_tlefile
     """

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -116,7 +116,7 @@ class Tle(object):
     def _read_tle(self):
 
         def _read_tle_decimal(rep):
-            if rep[0] in ["-", " "]:
+            if rep[0] in ["-", " ", "+"]:
                 val = rep[0] + "." + rep[1:-2] + "e" + rep[-2:]
             else:
                 val = "." + rep[:-2] + "e" + rep[-2:]


### PR DESCRIPTION
Sometimes, the value starts with a '+'.

Example:
1 25544U 98067A   15235.81765006 +.00009573 +00000-0 +14486-3 0  9999
2 25544 051.6452 106.3529 0001648 090.4174 004.9123 15.55401685958567

From https://celestrak.com/columns/v04n03/:
"Columns with a '+' can have either a plus sign, a minus sign, or a space and columns with a '-' can have either a plus or minus sign (if the rest of the field is not blank)."