### PR TITLE
Python3 fixes for fetch()

### DIFF
--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -142,10 +142,10 @@ def read(platform, tle_file=None, line1=None, line2=None):
 def fetch(destination):
     """fetch TLE from internet and save it to *destination*.
    """
-    with open(destination, "w") as dest:
+    with io.open(destination, mode="w", encoding="utf-8") as dest:
         for url in TLE_URLS:
             response = urlopen(url)
-            dest.write(response.read())
+            dest.write(response.read().decode("utf-8"))
 
 
 class ChecksumError(Exception):


### PR DESCRIPTION
@mraspaud please review this PR. It fixes the `fetch()` method when used with Python3. I've verified this fix in Python 2.7.10 and 3.5.0. 

Any questions, please let me know.