### PR TITLE
Add conditional check to use `da.where` when inputs are dask arrays

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -104,10 +104,10 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     cos_theta = np.cos(theta)
 
     top_s = sin_lat * cos_theta * rx + \
-            sin_lat * sin_theta * ry - cos_lat * rz
+        sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-            cos_lat * sin_theta * ry + sin_lat * rz
+        cos_lat * sin_theta * ry + sin_lat * rz
 
     az_ = np.arctan(-top_e / top_s)
 
@@ -124,6 +124,7 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     el_ = np.arcsin(top_z / rg_)
 
     return np.rad2deg(az_), np.rad2deg(el_)
+
 
 class Orbital(object):
 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -104,21 +104,26 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     cos_theta = np.cos(theta)
 
     top_s = sin_lat * cos_theta * rx + \
-        sin_lat * sin_theta * ry - cos_lat * rz
+            sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-        cos_lat * sin_theta * ry + sin_lat * rz
+            cos_lat * sin_theta * ry + sin_lat * rz
 
     az_ = np.arctan(-top_e / top_s)
 
-    az_ = np.where(top_s > 0, az_ + np.pi, az_)
-    az_ = np.where(az_ < 0, az_ + 2 * np.pi, az_)
+    if hasattr(az_, 'chunks'):
+        # dask array
+        import dask.array as da
+        az_ = da.where(top_s > 0, az_ + np.pi, az_)
+        az_ = da.where(az_ < 0, az_ + 2 * np.pi, az_)
+    else:
+        az_[top_s > 0] += np.pi
+        az_[az_ < 0] += 2 * np.pi
 
     rg_ = np.sqrt(rx * rx + ry * ry + rz * rz)
     el_ = np.arcsin(top_z / rg_)
 
     return np.rad2deg(az_), np.rad2deg(el_)
-
 
 class Orbital(object):
 


### PR DESCRIPTION
This adds a small if statement to see if the input to `get_observer_look` is a dask array and use `da.where` instead of doing in-place conditional writes which are not-dask friendly (unknown shape).

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

Travis tests seem to fail right now outside of my changes. @adybbroe @mraspaud ideas? Maybe a numpy version change?