### PR TITLE
Support xarray in get_observer_look

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
 - '2.7'
-- "3.5"
 - "3.6"
 install:
+- pip install dask[array] xarray
 - pip install .
 - pip install coveralls
 script: coverage run --source=pyorbital setup.py test

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -111,11 +111,15 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
 
     az_ = np.arctan(-top_e / top_s)
 
-    if hasattr(az_, 'chunks'):
-        # dask array
+    if hasattr(az_, 'chunks') and not hasattr(az_, 'loc'):
+        # dask array, but not xarray
         import dask.array as da
         az_ = da.where(top_s > 0, az_ + np.pi, az_)
         az_ = da.where(az_ < 0, az_ + 2 * np.pi, az_)
+    elif hasattr(az_, 'loc'):
+        # xarray
+        az_.data[top_s > 0] += np.pi
+        az_.data[az_.data < 0] += 2 * np.pi
     else:
         az_[top_s > 0] += np.pi
         az_[az_ < 0] += 2 * np.pi

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -38,54 +38,71 @@ class Test(unittest.TestCase):
     def test_get_orbit_number(self):
         """Testing getting the orbitnumber from the tle"""
         sat = orbital.Orbital("NPP",
-                              line1="1 37849U 11061A   12017.90990040 -.00000112  00000-0 -32693-4 0   772",
-                              line2="2 37849  98.7026 317.8811 0001845  92.4533 267.6830 14.19582686 11574")
+                              line1="1 37849U 11061A   12017.90990040 "
+                                    "-.00000112  00000-0 -32693-4 0   772",
+                              line2="2 37849  98.7026 317.8811 0001845  "
+                                    "92.4533 267.6830 14.19582686 11574")
         dobj = datetime(2012, 1, 18, 8, 4, 19)
         orbnum = sat.get_orbit_number(dobj)
         self.assertEqual(orbnum, 1163)
 
     def test_sublonlat(self):
         sat = orbital.Orbital("ISS (ZARYA)",
-                              line1="1 25544U 98067A   03097.78853147  .00021906  00000-0  28403-3 0  8652",
-                              line2="2 25544  51.6361  13.7980 0004256  35.6671  59.2566 15.58778559250029")
+                              line1="1 25544U 98067A   03097.78853147  "
+                                    ".00021906  00000-0  28403-3 0  8652",
+                              line2="2 25544  51.6361  13.7980 0004256  "
+                                    "35.6671  59.2566 15.58778559250029")
         d = datetime(2003, 3, 23, 0, 3, 22)
         lon, lat, alt = sat.get_lonlatalt(d)
         expected_lon = -68.199894472013213
         expected_lat = 23.159747677881075
         expected_alt = 392.01953430856935
-        self.assertTrue(np.abs(lon - expected_lon) < eps_deg, 'Calculation of sublon failed')
-        self.assertTrue(np.abs(lat - expected_lat) < eps_deg, 'Calculation of sublat failed')
-        self.assertTrue(np.abs(alt - expected_alt) < eps_deg, 'Calculation of altitude failed')
+        self.assertTrue(np.abs(lon - expected_lon) < eps_deg,
+                        'Calculation of sublon failed')
+        self.assertTrue(np.abs(lat - expected_lat) < eps_deg,
+                        'Calculation of sublat failed')
+        self.assertTrue(np.abs(alt - expected_alt) < eps_deg,
+                        'Calculation of altitude failed')
 
     def test_observer_look(self):
         sat = orbital.Orbital("ISS (ZARYA)",
-                              line1="1 25544U 98067A   03097.78853147  .00021906  00000-0  28403-3 0  8652",
-                              line2="2 25544  51.6361  13.7980 0004256  35.6671  59.2566 15.58778559250029")
+                              line1="1 25544U 98067A   03097.78853147  "
+                                    ".00021906  00000-0  28403-3 0  8652",
+                              line2="2 25544  51.6361  13.7980 0004256  "
+                                    "35.6671  59.2566 15.58778559250029")
         d = datetime(2003, 3, 23, 0, 3, 22)
         az, el = sat.get_observer_look(d, -84.39733, 33.775867, 0)
         expected_az = 122.45169655331965
         expected_el = 1.9800219611255456
-        self.assertTrue(np.abs(az - expected_az) < eps_deg, 'Calculation of azimut failed')
-        self.assertTrue(np.abs(el - expected_el) < eps_deg, 'Calculation of elevation failed')
+        self.assertTrue(np.abs(az - expected_az) < eps_deg,
+                        'Calculation of azimut failed')
+        self.assertTrue(np.abs(el - expected_el) < eps_deg,
+                        'Calculation of elevation failed')
 
     def test_orbit_num_an(self):
         sat = orbital.Orbital("METOP-A",
-                              line1="1 29499U 06044A   11254.96536486  .00000092  00000-0  62081-4 0  5221",
-                              line2="2 29499  98.6804 312.6735 0001758 111.9178 248.2152 14.21501774254058")
+                              line1="1 29499U 06044A   11254.96536486  "
+                                    ".00000092  00000-0  62081-4 0  5221",
+                              line2="2 29499  98.6804 312.6735 0001758 "
+                                    "111.9178 248.2152 14.21501774254058")
         d = datetime(2011, 9, 14, 5, 30)
         self.assertEqual(sat.get_orbit_number(d), 25437)
 
     def test_orbit_num_non_an(self):
         sat = orbital.Orbital("METOP-A",
-                              line1="1 29499U 06044A   13060.48822809  .00000017  00000-0  27793-4 0  9819",
-                              line2="2 29499  98.6639 121.6164 0001449  71.9056  43.3132 14.21510544330271")
+                              line1="1 29499U 06044A   13060.48822809  "
+                                    ".00000017  00000-0  27793-4 0  9819",
+                              line2="2 29499  98.6639 121.6164 0001449  "
+                                    "71.9056  43.3132 14.21510544330271")
         dt = np.timedelta64(98, 'm')
         self.assertEqual(sat.get_orbit_number(sat.tle.epoch + dt), 33028)
 
     def test_orbit_num_equator(self):
         sat = orbital.Orbital("SUOMI NPP",
-                              line1="1 37849U 11061A   13061.24611272  .00000048  00000-0  43679-4 0  4334",
-                              line2="2 37849  98.7444   1.0588 0001264  63.8791 102.8546 14.19528338 69643")
+                              line1="1 37849U 11061A   13061.24611272  "
+                                    ".00000048  00000-0  43679-4 0  4334",
+                              line2="2 37849  98.7444   1.0588 0001264  "
+                                    "63.8791 102.8546 14.19528338 69643")
         t1 = datetime(2013, 3, 2, 22, 2, 25)
         t2 = datetime(2013, 3, 2, 22, 2, 26)
         on1 = sat.get_orbit_number(t1)
@@ -100,14 +117,17 @@ class Test(unittest.TestCase):
 
     def test_get_next_passes_apogee(self):
         """Regression test #22."""
-        line1 = "1 24793U 97020B   18065.48735489  .00000075  00000-0  19863-4 0  9994"
-        line2 = "2 24793  86.3994 209.3241 0002020  89.8714 270.2713 14.34246429 90794"
+        line1 = "1 24793U 97020B   18065.48735489  " \
+                ".00000075  00000-0  19863-4 0  9994"
+        line2 = "2 24793  86.3994 209.3241 0002020  " \
+                "89.8714 270.2713 14.34246429 90794"
 
         orb = orbital.Orbital('IRIDIUM 7 [+]', line1=line1, line2=line2)
         d = datetime(2018, 3, 7, 3, 30, 15)
         res = orb.get_next_passes(d, 1, 170.556, -43.368, 0.5, horizon=40)
         self.assertTrue(abs(
-            res[0][2] - datetime(2018, 3, 7, 3, 48, 13, 178439)) < timedelta(seconds=0.01))
+            res[0][2] - datetime(2018, 3, 7, 3, 48, 13, 178439)) <
+                        timedelta(seconds=0.01))
 
 
 class TestGetObserverLook(unittest.TestCase):
@@ -154,7 +174,6 @@ class TestGetObserverLook(unittest.TestCase):
     def test_xarray_with_numpy(self):
         """Test with xarray DataArray with numpy array as inputs"""
         from pyorbital import orbital
-        import dask.array as da
         import xarray as xr
 
         def _xarr_conv(input):

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -127,7 +127,7 @@ class Test(unittest.TestCase):
         res = orb.get_next_passes(d, 1, 170.556, -43.368, 0.5, horizon=40)
         self.assertTrue(abs(
             res[0][2] - datetime(2018, 3, 7, 3, 48, 13, 178439)) <
-                        timedelta(seconds=0.01))
+            timedelta(seconds=0.01))
 
 
 class TestGetObserverLook(unittest.TestCase):

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -106,7 +106,8 @@ class Test(unittest.TestCase):
         orb = orbital.Orbital('IRIDIUM 7 [+]', line1=line1, line2=line2)
         d = datetime(2018, 3, 7, 3, 30, 15)
         res = orb.get_next_passes(d, 1, 170.556, -43.368, 0.5, horizon=40)
-        self.assertTrue(abs(res[0][2] - datetime(2018, 3, 7, 3, 48, 13, 178439)) < timedelta(seconds=0.01))
+        self.assertTrue(abs(
+            res[0][2] - datetime(2018, 3, 7, 3, 48, 13, 178439)) < timedelta(seconds=0.01))
 
 
 class TestGetObserverLook(unittest.TestCase):
@@ -189,6 +190,7 @@ class TestGetObserverLook(unittest.TestCase):
                                               lon, lat, alt)
         np.testing.assert_allclose(azi.data.compute(), self.exp_azi)
         np.testing.assert_allclose(elev.data.compute(), self.exp_elev)
+
 
 def suite():
     """The suite for test_orbital


### PR DESCRIPTION
get_observer_look was erroneously turning dask.array into xarray dataarrays..
However, the standard 'else:'-block did not work for xarray dataarrays.
either.  Add a special case 'elif:'-block for xarray dataarrays.

<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->

 - [x] Closes #30 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
