### PR TITLE
Fix documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,8 +28,8 @@ Pyorbital has a module for parsing NORAD TLE-files
 
 If no path is given pyorbital tries to read the earth observation TLE-files from celestrak.com
     
-Computing satellite postion
----------------------------
+Computing satellite position
+----------------------------
 The orbital module enables computation of satellite position and velocity at a specific time:
 
     >>> from pyorbital.orbital import Orbital
@@ -56,7 +56,7 @@ Use actual TLEs to increase accuracy
     >>> orb.get_lonlatalt(dtobj)
     (152.11564698762811, 20.475251739329622, 829.37355785502211)
 
-But since we are interesting knowing the position of the Suomi-NPP more than
+But since we are interested in knowing the position of the Suomi-NPP more than
 two and half years from now (September 26, 2017) we can not rely on the current
 TLEs, but rather need a TLE closer to the time of interest:
 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -131,7 +131,7 @@ class Orbital(object):
     """Class for orbital computations.
 
     The *satellite* parameter is the name of the satellite to work on and is
-    used to retreive the right TLE data for internet or from *tle_file* in case
+    used to retrieve the right TLE data for internet or from *tle_file* in case
     it is provided.
     """
 

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -130,7 +130,7 @@ class AIAAIntegrationTest(unittest.TestCase):
 
                         delta_pos = 5e-6  # km =  5 mm
                         delta_vel = 5e-9  # km/s = 5 um/s
-                        delta_time = 1e-3  # 1 milisecond
+                        delta_time = 1e-3  # 1 millisecond
                         self.assertTrue(abs(res[0] - pos[0]) < delta_pos)
                         self.assertTrue(abs(res[1] - pos[1]) < delta_pos)
                         self.assertTrue(abs(res[2] - pos[2]) < delta_pos)

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -78,63 +78,9 @@ SATELLITES = read_platform_numbers(in_upper=True, num_as_int=False)
 The platform numbers are given in a file $PPP_CONFIG/platforms.txt
 in the following format:
 
-# Mappings between satellite catalogue numbers and corresponding
-# platform names from OSCAR.
-ALOS-2 39766
-CloudSat 29107
-CryoSat-2 36508
-CSK-1 31598
-CSK-2 32376
-CSK-3 33412
-CSK-4 37216
-DMSP-F15 25991
-DMSP-F16 28054
-DMSP-F17 29522
-DMSP-F18 35951
-DMSP-F19 39630
-EOS-Aqua 27424
-EOS-Aura 28376
-EOS-Terra 25994
-FY-2D 29640
-FY-2E 33463
-FY-2F 38049
-FY-2G 40367
-FY-3A 32958
-FY-3B 37214
-FY-3C 39260
-GOES-13 29155
-GOES-14 35491
-GOES-15 36411
-Himawari-6 28622
-Himawari-7 28937
-Himawari-8 40267
-INSAT-3A 27714
-INSAT-3C 27298
-INSAT-3D 39216
-JASON-2 33105
-Kalpana-1 27525
-Landsat-7 25682
-Landsat-8 39084
-Meteosat-7 24932
-Meteosat-8 27509
-Meteosat-9 28912
-Meteosat-10 38552
-Metop-A 29499
-Metop-B 38771
-NOAA-15 25338
-NOAA-16 26536
-NOAA-17 27453
-NOAA-18 28654
-NOAA-19 33591
-RadarSat-2 32382
-Sentinel-1A 39634
-SMOS 36036
-SPOT-5 27421
-SPOT-6 38755
-SPOT-7 40053
-Suomi-NPP 37849
-TanDEM-X 36605
-TerraSAR-X 31698
+.. literalinclude:: ../../etc/platforms.txt
+  :language: text
+  :lines: 4-
 '''
 
 


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

This PR fixes some small errors in the documentation

<!-- Describe what your PR does, and why -->

The main difference is that this list:
![image](https://user-images.githubusercontent.com/1055635/44621800-09ade500-a8ad-11e8-9fa6-ce4543458bee.png)

is rendered with an item per line:
![image](https://user-images.githubusercontent.com/1055635/44621970-18e26200-a8b0-11e8-88e3-5bc689cb7929.png)

The list now is taken from the actual `platforms.txt` file so it is always up to date and now it shows also the following satellites:
 +FY-3D 43010
 +GOES-16 41866
 +Himawari-9 41836
 +Meteosat-11 40732
 +NOAA-20 43013

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
