### PR TITLE
Add celestrak amateur.txt to TLE_URLS in tlefile.py

### DIFF
--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -39,7 +39,8 @@ TLE_URLS = ('http://celestrak.com/NORAD/elements/weather.txt',
             'https://www.celestrak.com/NORAD/elements/cubesat.txt',
             'http://celestrak.com/NORAD/elements/stations.txt',
             'https://www.celestrak.com/NORAD/elements/sarsat.txt',
-            'https://www.celestrak.com/NORAD/elements/noaa.txt')
+            'https://www.celestrak.com/NORAD/elements/noaa.txt',
+            'https://www.celestrak.com/NORAD/elements/amateur.txt')
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This PR adds amateur radio satellites to the list of URLS that TLEs are fetched from.