### PR TITLE
Changed get_observer_look function to match Oribtal.get_observer_look

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -98,6 +98,8 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
 
     Return: (Azimuth, Elevation)
     """
+
+    utc_time = dt2np(utc_time)
     (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = astronomy.observer_position(
         utc_time, sat_lon, sat_lat, sat_alt)
 
@@ -126,22 +128,8 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
 
     az_ = np.arctan(-top_e / top_s)
 
-    if has_xarray and isinstance(az_, xr.DataArray):
-        az_data = az_.data
-    else:
-        az_data = az_
-
-    if has_dask and isinstance(az_data, da.Array):
-        az_data = da.where(top_s > 0, az_data + np.pi, az_data)
-        az_data = da.where(az_data < 0, az_data + 2 * np.pi, az_data)
-    else:
-        az_data[np.where(top_s > 0)] += np.pi
-        az_data[np.where(az_data < 0)] += 2 * np.pi
-
-    if has_xarray and isinstance(az_, xr.DataArray):
-        az_.data = az_data
-    else:
-        az_ = az_data
+    az_ = np.where(top_s > 0, az_ + np.pi, az_)
+    az_ = np.where(az_ < 0, az_ + 2 * np.pi, az_)
 
     rg_ = np.sqrt(rx * rx + ry * ry + rz * rz)
     el_ = np.arcsin(top_z / rg_)


### PR DESCRIPTION
The orbital.get_observer_look stand alone function produced an error so I have changed the code to match the function contained within the Orbital class. Now no error is raised when passing the stand alone function the lats and lons for the satellite and observer and the calculations are consistent through the program.

<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
