### PR TITLE
Fix tests on i386

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -544,8 +544,8 @@ class Orbital(object):
 
         try:
             tcross = optimize.bisect(_nprime,
-                                     a=np.datetime64(tstart, time_unit).astype(int),
-                                     b=np.datetime64(tend, time_unit).astype(int),
+                                     a=np.datetime64(tstart, time_unit).astype(np.int64),
+                                     b=np.datetime64(tend, time_unit).astype(np.int64),
                                      rtol=rtol)
         except ValueError:
             # Bisection did not converge


### PR DESCRIPTION
The test on get_equatorial_crossing_time fails on i386 platforms (see also https://tests.reproducible-builds.org/debian/rb-pkg/bullseye/i386/pyorbital.html)

```
======================================================================
ERROR: test_get_equatorial_crossing_time (pyorbital.tests.test_orbital.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/mock.py", line 1325, in patched
    return func(*newargs, **newkeywargs)
  File "/build/pyorbital-1.6.0/pyorbital/tests/test_orbital.py", line 189, in test_get_equatorial_crossing_time
    self.assertTrue((res - exp) < timedelta(seconds=0.01))
TypeError: unsupported operand type(s) for -: 'NoneType' and 'datetime.datetime'

----------------------------------------------------------------------
Ran 38 tests in 1.565s

FAILED (errors=1)
```

This PR should fix the issue.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
