### PR TITLE
Skip tests if data are not available

### DIFF
--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -79,10 +79,15 @@ def get_results(satnumber, delay):
             line = f_2.readline()
 
 
+_DATAPATH = os.path.dirname(os.path.abspath(__file__))
+
 class AIAAIntegrationTest(unittest.TestCase):
     """Test against the AIAA test cases.
     """
 
+    @unittest.skipIf(
+        not os.path.exists(os.path.join(_DATAPATH, "SGP4-VER.TLE")),
+        'SGP4-VER.TLE not available')
     def test_aiaa(self):
         """Do the tests against AIAA test cases.
         """


### PR DESCRIPTION
Test `test_aiaa` fails when the package is installed due to missing data. E.g.

```
$ python3 -m pytest --pyargs pyorbital
```

`test_aiaa`, indeed uses `SGP4-VER.TLE` which is not installed together with the test code.

This patch fixes the issue by skipping the test when data are not available.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital``
