### PR TITLE
Fix inappropriate runtime warning

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -22,8 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Module for computing the orbital parameters of satellites.
-"""
+"""Module for computing the orbital parameters of satellites."""
 
 import warnings
 from datetime import datetime, timedelta
@@ -390,18 +389,19 @@ class Orbital(object):
             f_c = fun(c)
 
             x = b
+            with np.errstate(invalid='raise'):
+                while True:
+                    try:
+                        x = x - 0.5 * (((b - a) ** 2 * (f_b - f_c)
+                                        - (b - c) ** 2 * (f_b - f_a)) /
+                                    ((b - a) * (f_b - f_c) - (b - c) * (f_b - f_a)))
+                    except FloatingPointError:
+                        return b
+                    if abs(b - x) <= tol:
+                        return x
 
-            while True:
-                x = x - 0.5 * (((b - a) ** 2 * (f_b - f_c)
-                                - (b - c) ** 2 * (f_b - f_a)) /
-                               ((b - a) * (f_b - f_c) - (b - c) * (f_b - f_a)))
-                if np.isnan(x):
-                    return b
-                if abs(b - x) <= tol:
-                    return x
-
-                a, b, c = (a + x) / 2.0, x, (x + c) / 2.0
-                f_a, f_b, f_c = fun(a), fun(b), fun(c)
+                    a, b, c = (a + x) / 2.0, x, (x + c) / 2.0
+                    f_a, f_b, f_c = fun(a), fun(b), fun(c)
 
         # every minute
         times = utc_time + np.array([timedelta(minutes=minutes)

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -394,7 +394,7 @@ class Orbital(object):
                     try:
                         x = x - 0.5 * (((b - a) ** 2 * (f_b - f_c)
                                         - (b - c) ** 2 * (f_b - f_a)) /
-                                    ((b - a) * (f_b - f_c) - (b - c) * (f_b - f_a)))
+                                       ((b - a) * (f_b - f_c) - (b - c) * (f_b - f_a)))
                     except FloatingPointError:
                         return b
                     if abs(b - x) <= tol:

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -109,10 +109,10 @@ class TestGeoloc(unittest.TestCase):
         start_of_scan = np.datetime64(datetime(2014, 1, 8, 11, 30))
         times = instrument.times(start_of_scan)
 
-        self.assertEquals(times[0, 1], start_of_scan)
-        self.assertEquals(times[0, 0], start_of_scan -
+        self.assertEqual(times[0, 1], start_of_scan)
+        self.assertEqual(times[0, 0], start_of_scan -
                           np.timedelta64(100, 'ms'))
-        self.assertEquals(times[0, 2], start_of_scan +
+        self.assertEqual(times[0, 2], start_of_scan +
                           np.timedelta64(100, 'ms'))
 
     def test_geodetic_lat(self):

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -293,8 +293,8 @@ class TestRegressions(unittest.TestCase):
         from dateutil import parser
         warnings.filterwarnings('error')
         orb = Orbital("Suomi-NPP",
-                    line1="1 37849U 11061A   19292.84582509  .00000011  00000-0  25668-4 0  9997",
-                    line2="2 37849  98.7092 229.3263 0000715  98.5313 290.6262 14.19554485413345")
+                      line1="1 37849U 11061A   19292.84582509  .00000011  00000-0  25668-4 0  9997",
+                      line2="2 37849  98.7092 229.3263 0000715  98.5313 290.6262 14.19554485413345")
         orb.get_next_passes(parser.parse("2019-10-21 16:00:00"), 12, 123.29736, -13.93763, 0)
         warnings.filterwarnings('default')
 

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -283,6 +283,22 @@ class TestGetObserverLook(unittest.TestCase):
         np.testing.assert_allclose(elev.data.compute(), self.exp_elev)
 
 
+class TestRegressions(unittest.TestCase):
+    """Test regressions."""
+
+    def test_63(self):
+        """Check that no runtimewarning is raised, #63."""
+        import warnings
+        from pyorbital.orbital import Orbital
+        from dateutil import parser
+        warnings.filterwarnings('error')
+        orb = Orbital("Suomi-NPP",
+                    line1="1 37849U 11061A   19292.84582509  .00000011  00000-0  25668-4 0  9997",
+                    line2="2 37849  98.7092 229.3263 0000715  98.5313 290.6262 14.19554485413345")
+        orb.get_next_passes(parser.parse("2019-10-21 16:00:00"), 12, 123.29736, -13.93763, 0)
+        warnings.filterwarnings('default')
+
+
 def suite():
     """The suite for test_orbital
     """
@@ -290,5 +306,6 @@ def suite():
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(Test))
     mysuite.addTest(loader.loadTestsFromTestCase(TestGetObserverLook))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestRegressions))
 
     return mysuite


### PR DESCRIPTION
This PR fixes an annoying warning that the algorithm was generating (even if it was supposed to happen)

 - [x] Closes #63  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
