### PR TITLE
Added CALIPSO among platforms

### DIFF
--- a/pyorbital/etc/platforms.txt
+++ b/pyorbital/etc/platforms.txt
@@ -5,6 +5,7 @@
 # platform names from OSCAR.
 ALOS-2 39766
 CloudSat 29107
+CALIPSO 29108
 CryoSat-2 36508
 CSK-1 31598
 CSK-2 32376


### PR DESCRIPTION
Added CALIPSO NORAD ID  (29108) in platform.txt to be able to parse TLEs for CALIPSO.

 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->

