### PR TITLE
Handle TLE archives with multiple entries

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -174,12 +174,12 @@ class Orbital(object):
             tle_data = self.read_tle_file(self.tle_file)
             dates = self.tle2datetime64(
                 np.array([float(line[18:32]) for line in tle_data[::2]]))
-            
+
             #  set utctime to arbitrary value inside archive if object init
             if self.utctime is None:
                 sdate = dates[-1]
             else:
-                sdate = np.datetime64(self.utctime) #.timestamp() #self.utcs[0]
+                sdate = np.datetime64(self.utctime)  # .timestamp() #self.utcs[0]
             # Find index "iindex" such that dates[iindex-1] < sdate <= dates[iindex]
             # Notes:
             #     1. If sdate < dates[0] then iindex = 0
@@ -202,18 +202,18 @@ class Orbital(object):
                     "Can't find tle data for %s within +/- %d days around %s" %
                     (self.satellite_name, tle_thresh, sdate))
 
-            #if delta_days > 3:
-            #    LOG.warning("Found TLE data for %s that is %f days appart",
-            #                sdate, delta_days)
-            #else:
-            #    LOG.debug("Found TLE data for %s that is %f days appart",
-            #              sdate, delta_days)
+            # if delta_days > 3:
+            #     LOG.warning("Found TLE data for %s that is %f days appart",
+            #                 sdate, delta_days)
+            # else:
+            #     LOG.debug("Found TLE data for %s that is %f days appart",
+            #               sdate, delta_days)
 
             # Select TLE data
             tle1 = tle_data[iindex * 2]
             tle2 = tle_data[iindex * 2 + 1]
             self._tle = tlefile.read(self.satellite_name, tle_file=None,
-                                    line1=tle1, line2=tle2)
+                                     line1=tle1, line2=tle2)
 
         # Not using TLE archive;
         # Either using current celestrek TLE,
@@ -223,12 +223,12 @@ class Orbital(object):
             # Object just created
             if not self.utctime:
                 self.utctime = datetime.now()
-            mismatch = self.utctime - sat_time.as_type(datetime)
+            mismatch = self.utctime - sat_time.astype(datetime)
             if mismatch.days > abs(7):
                 raise IndexError(
-                   """Current TLE from celestrek is %d days newer than 
-                     requested orbital parameter. Please use TLE archive
-                     for accurate results""" %
+                    """Current TLE from celestrek is %d days newer than
+                       requested orbital parameter. Please use TLE archive
+                       for accurate results""" %
                     (mismatch.days))
 
         return self._tle
@@ -239,7 +239,8 @@ class Orbital(object):
 
     @property
     def orbit_elements(self):
-        return OrbitElements(self.tle)        
+        return OrbitElements(self.tle)
+
     @orbit_elements.setter
     def orbit_elements(self, new_orbit_elements):
         self._orbit_elements = new_orbit_elements
@@ -247,6 +248,7 @@ class Orbital(object):
     @property
     def sgdp4(self):
         return _SGDP4(self.orbit_elements)
+
     @sgdp4.setter
     def sgdp4(self, new_sgdp4):
         self._sgdp4 = _SGDP4(self.orbit_elements)
@@ -254,11 +256,12 @@ class Orbital(object):
     @property
     def utctime(self):
         return self._utctime
+
     @utctime.setter
     def utctime(self, utc_time):
         if type(utc_time) is not datetime:
-            times = np.array(utc_time, dtype = 'datetime64[m]')
-            if times.max() - times.min() > np.timedelta64(3,'D'):
+            times = np.array(utc_time, dtype='datetime64[m]')
+            if times.max() - times.min() > np.timedelta64(3, 'D'):
                 raise ValueError(
                         "Dates must not exceed 3 days")
             utctime = np.array(times.astype(float).mean(),

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -169,11 +169,13 @@ class Orbital(object):
 
     @property
     def tle(self):
+        # using an archive; select appropriate TLE from file
         if self.tle_file:
             tle_data = self.read_tle_file(self.tle_file)
             dates = self.tle2datetime64(
                 np.array([float(line[18:32]) for line in tle_data[::2]]))
             
+            #  set utctime to arbitrary value inside archive if object init
             if self.utctime is None:
                 sdate = dates[-1]
             else:
@@ -212,6 +214,22 @@ class Orbital(object):
             tle2 = tle_data[iindex * 2 + 1]
             self._tle = tlefile.read(self.satellite_name, tle_file=None,
                                     line1=tle1, line2=tle2)
+
+        # Not using TLE archive;
+        # Either using current celestrek TLE,
+        # or using user supplied Line 1 and line 2
+        else:
+            sat_time = self.tle2datetime64(float(self._tle.line1[18:32]))
+            # Object just created
+            if self.utctime = None:
+                self.utctime = datetime.now()
+            mismatch = self.utctime - sat_time
+            if mismatch.days > abs(7):
+                raise IndexError(
+                    "Current TLE from celestrek is %d days newer than 
+                     requested orbital parameter. Please use TLE archive
+                     for accurate results" %
+                    (mismatch.days))
 
         return self._tle
 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -226,9 +226,9 @@ class Orbital(object):
             mismatch = self.utctime - sat_time
             if mismatch.days > abs(7):
                 raise IndexError(
-                    "Current TLE from celestrek is %d days newer than 
+                   """Current TLE from celestrek is %d days newer than 
                      requested orbital parameter. Please use TLE archive
-                     for accurate results" %
+                     for accurate results""" %
                     (mismatch.days))
 
         return self._tle

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -224,7 +224,7 @@ class Orbital(object):
             if not self.utctime:
                 self.utctime = datetime.now()
             mismatch = self.utctime - sat_time.astype(datetime)
-            if mismatch.days > abs(7):
+            if abs(mismatch.days) > 7:
                 raise IndexError(
                     """Current TLE from celestrek is %d days newer than
                        requested orbital parameter. Please use TLE archive

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -223,7 +223,7 @@ class Orbital(object):
             # Object just created
             if not self.utctime:
                 self.utctime = datetime.now()
-            mismatch = self.utctime - sat_time
+            mismatch = self.utctime - sat_time.as_type(datetime)
             if mismatch.days > abs(7):
                 raise IndexError(
                    """Current TLE from celestrek is %d days newer than 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -223,13 +223,12 @@ class Orbital(object):
             # Object just created
             if not self.utctime:
                 self.utctime = datetime.now()
-            mismatch = self.utctime - sat_time.astype(datetime)
+            mismatch = sat_time.astype(datetime) - self.utctime
             if abs(mismatch.days) > 7:
-                raise IndexError(
-                    """Current TLE from celestrek is %d days newer than
-                       requested orbital parameter. Please use TLE archive
-                       for accurate results""" %
-                    (mismatch.days))
+                raise IndexError("""
+                    Current TLE from celestrek is %d days newer than
+                    requested orbital parameter. Please use TLE archive
+                    for accurate results""" % (mismatch.days))
 
         return self._tle
 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -221,7 +221,7 @@ class Orbital(object):
         else:
             sat_time = self.tle2datetime64(float(self._tle.line1[18:32]))
             # Object just created
-            if self.utctime = None:
+            if not self.utctime:
                 self.utctime = datetime.now()
             mismatch = self.utctime - sat_time
             if mismatch.days > abs(7):


### PR DESCRIPTION
This PR adds TLE archive parsing to grab the correct TLE based on the specified UTC time. This is in response to #70 , where calling `get_lonlatalt` can give very spurious results when the orbital parameters are propagated over long time intervals (i.e., months, years, or decades). The solution is to use TLE archives... but the current version of pyorbital only grabs the first TLE and doesn't check for closest in time to the query. I've added a single new parameter, `self.utctime`, that is updated whenever a function requests a utctime input from the user (e.g., `get_lonlatalt()`). I also changed how the orbital parameters are stored in the object-- getting `self.sgdp4` forces a call on `self.orbit_elements`, which returns the evaluation of `OrbitElements(self.tle)`, and similarly forces evaluation of `self.tle`, which on read parses for the correct TLE based on the parameter `utctime`. In other words, the orbital parameters are dynamically calculated and returned based off of the last update to `utctime` , instead of created as static values that are stored in the object.

A couple of caveats:

 - There is new error behavior for poor matches between TLE parameters and requests for positional information. One of the things that was frustrating about #70 was that there was no indication that the returned orbital positions were wrong, in some cases by a full hemisphere. As written, calling a position with a mismatch on the TLE and the utctime parameter by more than a week raises an exception. This could be changed to a warning--or a warning for small values (3 days?) and an exception for large ones (a month?)-- but there should probably be some hard check or user warning when you can tell that the returned answers will be demonstrably false. @mraspaud I'm guessing that you have some opinions on how strict these limits should be, at what point warnings vs exceptions are appropriate, and how much of a social contract for the library is in place that output is expected even when propagated over long time scales...
 - The above exception is raised for cases where no archive is provided too. Default behavior for `tlefile.Read()` when `tle_file=None` is to fetch from celestrak. That's fine and still works, but if no TLE archive is specified, and a location for a year ago is requested, an exception occurs just as it would if a TLE archive was supplied but the `utctime` parameter supplied by the user wasn't in archive or close to it. (Same for if the TLE Line1 and Line2 values are provided at time of object creation as strings). If the current TLE from celestrek or user string is close (within a week) to the utctime query, everything works as expected.
 - Lists and array input of datetime objects or numpy timestamps still works fine...but there is a restriction on the total spread of the timestamps. Let's say that you want to query 800 times for the location of a satellite over a day or two; that's fine, no issue--the mean of the times supplied is used to lookup the closest TLE in the archive and the calculations for the positions is run as an array. On the other hand, let's say that you pass an array of 100 datetime objects that are spread over a decade; this is a problem because there's no way to select a single TLE that is appropriate, and no obvious heuristic for how to chunk the calculations by segmenting orbital calculation updates. The way this is handled is that an error is passed if the list or array of times is spread over more than 3 days; for that, the call to the `Orbital` object needs to be wrapped in a loop so that the object can update the dates and TLE selection.
 - The creation signature for `Orbital` is unchanged. The new attribute `utctime` could be added as another positional argument if desired...right now it is either set as None and inferred at runtime when a time is provided, inferred from the TLE that is used at object creation, or set to `datetime.now()` if the most recent TLE from celestrek is used. 
 - Tests have been run for this interactively... just not written and added. Guessing that determining when an exception vs warning should be raised will inform how the tests are run.

 - [x] Closes #70 
 - [ ] Tests added 
 - [ ] Tests passed 
 - [x] Passes ``flake8 pyorbital`` 
 - [x] Fully documented (comments in code, no user documentation)
