### PR TITLE
Add parser to read TLEs from Multi Mission Administrative Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Pyorbital
 =========
 
-[![Build status](https://github.com/pytroll/pyorbital/workflows/CI/badge.svg?branch=master)](https://github.com/pytroll/pyorbital/workflows/CI/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/pytroll/pyorbital/badge.svg?branch=master)](https://coveralls.io/github/pytroll/pyorbital?branch=master)
+[![Build status](https://github.com/pytroll/pyorbital/workflows/CI/badge.svg?branch=main)](https://github.com/pytroll/pyorbital/workflows/CI/badge.svg?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/pytroll/pyorbital/badge.svg?branch=main)](https://coveralls.io/github/pytroll/pyorbital?branch=main)
 [![PyPI version](https://badge.fury.io/py/pyorbital.svg)](https://badge.fury.io/py/pyorbital)
 
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing Pyorbital
 
-1. checkout master
+1. checkout main branch
 2. pull from repo
 3. run the unittests
 4. run `loghub` and update the `CHANGELOG.md` file:

--- a/examples/tle.yaml
+++ b/examples/tle.yaml
@@ -40,6 +40,11 @@ downloaders:
   fetch_spacetrack:
     user: <username>
     password: <password>
+  read_xml_admin_messages:
+    # Direct reception data from Metop satellites have Eumetsat admin messages in them.  This can be used
+    #   to read the TLEs from the XML variants
+    paths:
+      - /path/to/xml/admin/messages/*ADMIN_MESSAGE*xml
   read_tle_files:
     # For "kickstarting" the database, local files can also be added
     paths:

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -38,6 +38,27 @@ line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"
 line1_2 = "1 38771U 12049A   21137.30264622  .00000000  00000+0 -49996-5 0 00017"
 line2_2 = "2 38771  98.7162 197.7716 0002383 106.1049 122.6344 14.21477797449453"
 
+tle_xml = '\n'.join(
+    ('<?xml version="1.0" encoding="UTF-8"?>',
+        '<multi-mission-administrative-message>',
+        '<message>',
+        '<two-line-elements>',
+        '<navigation>',
+        '<line-1>' + line1 + '</line-1>',
+        '<line-2>' + line2 + '</line-2>',
+        '</navigation>',
+        '</two-line-elements>',
+        '</message>',
+        '<message>',
+        '<two-line-elements>',
+        '<navigation>',
+        '<line-1>' + line1_2 + '</line-1>',
+        '<line-2>' + line2_2 + '</line-2>',
+        '</navigation>',
+        '</two-line-elements>',
+        '</message>',
+        '</multi-mission-administrative-message>'))
+
 
 class TLETest(unittest.TestCase):
     """Test TLE reading.
@@ -95,6 +116,18 @@ class TLETest(unittest.TestCase):
             self.check_example(tle)
         finally:
             remove(filename)
+
+    def test_from_mmam_xml(self):
+        """Test reading from an MMAM XML file."""
+        from tempfile import TemporaryDirectory
+
+        save_dir = TemporaryDirectory()
+        with save_dir:
+            fname = os.path.join(save_dir.name, '20210420_Metop-B_ADMIN_MESSAGE_NO_127.xml')
+            with open(fname, 'w') as fid:
+                fid.write(tle_xml)
+            tle = Tle("", tle_file=fname)
+        self.check_example(tle)
 
 
 FETCH_PLAIN_TLE_CONFIG = {
@@ -274,27 +307,6 @@ class TestDownloader(unittest.TestCase):
     def test_read_xml_admin_messages(self):
         """Test reading TLE files from a file system."""
         from tempfile import TemporaryDirectory
-
-        tle_xml = '\n'.join(
-            ('<?xml version="1.0" encoding="UTF-8"?>',
-             '<multi-mission-administrative-message>',
-             '<message>',
-             '<two-line-elements>',
-             '<navigation>',
-             '<line-1>' + line1 + '</line-1>',
-             '<line-2>' + line2 + '</line-2>',
-             '</navigation>',
-             '</two-line-elements>',
-             '</message>',
-             '<message>',
-             '<two-line-elements>',
-             '<navigation>',
-             '<line-1>' + line1_2 + '</line-1>',
-             '<line-2>' + line2_2 + '</line-2>',
-             '</navigation>',
-             '</two-line-elements>',
-             '</message>',
-             '</multi-mission-administrative-message>'))
 
         save_dir = TemporaryDirectory()
         with save_dir:

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -266,25 +266,26 @@ class TestDownloader(unittest.TestCase):
 
     def test_parse_tles(self):
         """Test TLE parsing."""
+        from pyorbital.tlefile import parse_tles_from_raw_data
         tle_text = '\n'.join((line0, line1, line2))
 
         # Valid data
-        res = self.dl.parse_tles(tle_text)
+        res = parse_tles_from_raw_data(tle_text)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0].line1, line1)
         self.assertEqual(res[0].line2, line2)
 
         # Only one valid line
-        res = self.dl.parse_tles(line1 + '\nbar')
+        res = parse_tles_from_raw_data(line1 + '\nbar')
         self.assertTrue(res == [])
 
         # Valid start of the lines, but bad data
-        res = self.dl.parse_tles('1 foo\n2 bar')
+        res = parse_tles_from_raw_data('1 foo\n2 bar')
         self.assertTrue(res == [])
 
         # Something wrong in the data
         bad_line2 = '2 ' + 'x' * (len(line2)-2)
-        res = self.dl.parse_tles('\n'.join((line1, bad_line2)))
+        res = parse_tles_from_raw_data('\n'.join((line1, bad_line2)))
         self.assertTrue(res == [])
 
 

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -280,30 +280,6 @@ class TestDownloader(unittest.TestCase):
         self.assertEqual(res[1].line1, line1_2)
         self.assertEqual(res[1].line2, line2_2)
 
-    def test_parse_tles(self):
-        """Test TLE parsing."""
-        from pyorbital.tlefile import parse_tles_from_raw_data
-        tle_text = '\n'.join((line0, line1, line2))
-
-        # Valid data
-        res = parse_tles_from_raw_data(tle_text)
-        self.assertEqual(len(res), 1)
-        self.assertEqual(res[0].line1, line1)
-        self.assertEqual(res[0].line2, line2)
-
-        # Only one valid line
-        res = parse_tles_from_raw_data(line1 + '\nbar')
-        self.assertTrue(res == [])
-
-        # Valid start of the lines, but bad data
-        res = parse_tles_from_raw_data('1 foo\n2 bar')
-        self.assertTrue(res == [])
-
-        # Something wrong in the data
-        bad_line2 = '2 ' + 'x' * (len(line2)-2)
-        res = parse_tles_from_raw_data('\n'.join((line1, bad_line2)))
-        self.assertTrue(res == [])
-
 
 class TestSQLiteTLE(unittest.TestCase):
     """Test saving TLE data to a SQLite database."""

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -35,6 +35,9 @@ line0 = "ISS (ZARYA)"
 line1 = "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927"
 line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"
 
+line1_2 = "1 38771U 12049A   21137.30264622  .00000000  00000+0 -49996-5 0 00017"
+line2_2 = "2 38771  98.7162 197.7716 0002383 106.1049 122.6344 14.21477797449453"
+
 
 class TLETest(unittest.TestCase):
     """Test TLE reading.
@@ -243,6 +246,14 @@ class TestDownloader(unittest.TestCase):
              '</navigation>',
              '</two-line-elements>',
              '</message>',
+             '<message>',
+             '<two-line-elements>',
+             '<navigation>',
+             '<line-1>' + line1_2 + '</line-1>',
+             '<line-2>' + line2_2 + '</line-2>',
+             '</navigation>',
+             '</two-line-elements>',
+             '</message>',
              '</multi-mission-administrative-message>'))
 
         save_dir = TemporaryDirectory()
@@ -260,9 +271,14 @@ class TestDownloader(unittest.TestCase):
                 }
             }
             res = self.dl.read_xml_admin_messages()
-        self.assertEqual(len(res), 2)
+
+        # There are two sets of TLEs in the file.  And as the same file is
+        # parsed twice, 4 TLE objects are returned
+        self.assertEqual(len(res), 4)
         self.assertEqual(res[0].line1, line1)
         self.assertEqual(res[0].line2, line2)
+        self.assertEqual(res[1].line1, line1_2)
+        self.assertEqual(res[1].line2, line2_2)
 
     def test_parse_tles(self):
         """Test TLE parsing."""

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -206,7 +206,6 @@ class TestDownloader(unittest.TestCase):
     def test_read_tle_files(self):
         """Test reading TLE files from a file system."""
         from tempfile import TemporaryDirectory
-        import os
 
         tle_text = '\n'.join((line0, line1, line2))
 
@@ -232,7 +231,6 @@ class TestDownloader(unittest.TestCase):
     def test_read_xml_admin_messages(self):
         """Test reading TLE files from a file system."""
         from tempfile import TemporaryDirectory
-        import os
 
         tle_xml = '\n'.join(
             ('<?xml version="1.0" encoding="UTF-8"?>',

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -236,16 +236,16 @@ class TestDownloader(unittest.TestCase):
 
         tle_xml = '\n'.join(
             ('<?xml version="1.0" encoding="UTF-8"?>',
-            '<multi-mission-administrative-message>',
-            '<message>',
-            '<two-line-elements>',
-            '<navigation>',
-            '<line-1>' + line1 + '</line-1>',
-            '<line-2>' + line2 + '</line-2>',
-            '</navigation>',
-            '</two-line-elements>',
-            '</message>',
-            '</multi-mission-administrative-message>'))
+             '<multi-mission-administrative-message>',
+             '<message>',
+             '<two-line-elements>',
+             '<navigation>',
+             '<line-1>' + line1 + '</line-1>',
+             '<line-2>' + line2 + '</line-2>',
+             '</navigation>',
+             '</two-line-elements>',
+             '</message>',
+             '</multi-mission-administrative-message>'))
 
         save_dir = TemporaryDirectory()
         with save_dir:

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -400,7 +400,6 @@ class Downloader(object):
 
         return tles
 
-
     def parse_tles(self, raw_data):
         """Parse all the TLEs in the given raw text data."""
         tles = []

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -28,10 +28,7 @@
 import io
 import logging
 import datetime as dt
-try:
-    from urllib2 import urlopen
-except ImportError:
-    from urllib.request import urlopen
+from urllib.request import urlopen
 import os
 import glob
 import numpy as np
@@ -246,12 +243,7 @@ class Tle(object):
     def __str__(self):
         """Format the class data for printing."""
         import pprint
-        import sys
-        if sys.version_info < (3, 0):
-            from StringIO import StringIO
-        else:
-            from io import StringIO
-        s_var = StringIO()
+        s_var = io.StringIO()
         d_var = dict(([(k, v) for k, v in
                        list(self.__dict__.items()) if k[0] != '_']))
         pprint.pprint(d_var, s_var)

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -38,6 +38,7 @@ import numpy as np
 import requests
 import sqlite3
 
+
 TLE_URLS = ('http://www.celestrak.com/NORAD/elements/active.txt',
             'http://celestrak.com/NORAD/elements/weather.txt',
             'http://celestrak.com/NORAD/elements/resource.txt',
@@ -366,15 +367,7 @@ class Downloader(object):
         paths = self.config["downloaders"]["read_tle_files"]["paths"]
 
         # Collect filenames
-        fnames = []
-        for path in paths:
-            if '*' in path:
-                fnames += glob.glob(path)
-            else:
-                if not os.path.exists(path):
-                    logging.error("File %s doesn't exist.", path)
-                    continue
-                fnames += [path]
+        fnames = collect_fnames(paths)
 
         tles = []
         for fname in fnames:
@@ -409,6 +402,20 @@ class Downloader(object):
                     tles.append(tle)
                 line1, line2 = None, None
         return tles
+
+
+def collect_fnames(paths):
+    """Collect all filenames from *paths*."""
+    fnames = []
+    for path in paths:
+        if '*' in path:
+            fnames += glob.glob(path)
+        else:
+            if not os.path.exists(path):
+                logging.error("File %s doesn't exist.", path)
+                continue
+            fnames += [path]
+    return fnames
 
 
 class SQLiteTLE(object):

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -260,8 +260,8 @@ def _get_uris_and_open_func(tle_file=None):
             uris = (tle_file,)
             open_func = _dummy_open_stringio
         elif "ADMIN_MESSAGE" in tle_file:
-            uris = (read_tle_from_mmam_xml_file(tle_file),)
-            open_func = io.StringIO
+            uris = (io.StringIO(read_tle_from_mmam_xml_file(tle_file)),)
+            open_func = _dummy_open_stringio
         else:
             uris = (tle_file,)
             open_func = _open

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -97,6 +97,7 @@ in the following format:
   :lines: 4-
 """
 
+
 def _dummy_open_stringio(stream):
     return stream
 
@@ -295,15 +296,12 @@ def _get_tles_from_uris(uris, open_func, platform='', only_first=True):
                 l_1 = _decode(next(fid))
                 l_2 = _decode(next(fid))
                 tle = l_1.strip() + "\n" + l_2.strip()
-            elif((platform in SATELLITES or not only_first) and
-                l_0.strip().startswith(designator)):
+            elif((platform in SATELLITES or not only_first) and l_0.strip().startswith(designator)):
                 l_1 = l_0
                 l_2 = _decode(next(fid))
                 tle = l_1.strip() + "\n" + l_2.strip()
                 if platform:
-                    LOGGER.debug("Found platform %s, ID: %s",
-                                platform,
-                                SATELLITES[platform])
+                    LOGGER.debug("Found platform %s, ID: %s", platform, SATELLITES[platform])
             elif open_func == _dummy_open_stringio and l_0.startswith(designator):
                 l_1 = l_0
                 l_2 = _decode(next(fid))

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -397,7 +397,7 @@ class Downloader(object):
         paths = self.config["downloaders"]["read_tle_files"]["paths"]
 
         # Collect filenames
-        fnames = collect_fnames(paths)
+        fnames = collect_filenames(paths)
         tles = _parse_tles_for_downloader(fnames, open)
         logging.info("Loaded %d TLEs from local files", len(tles))
 
@@ -417,7 +417,7 @@ def _parse_tles_for_downloader(item, open_func):
             _get_tles_from_uris(item, open_func, platform='', only_first=False)]
 
 
-def collect_fnames(paths):
+def collect_filenames(paths):
     """Collect all filenames from *paths*."""
     fnames = []
     for path in paths:
@@ -433,7 +433,7 @@ def collect_fnames(paths):
 
 def read_tles_from_mmam_xml_files(paths):
     # Collect filenames
-    fnames = collect_fnames(paths)
+    fnames = collect_filenames(paths)
     tles = []
     for fname in fnames:
         data = read_tle_from_mmam_xml_file(fname).split('\n')

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -382,11 +382,10 @@ class Downloader(object):
 
     def read_xml_admin_messages(self):
         """Read Eumetsat admin messages in XML format."""
-        paths = self.config["downloaders"]["read_admin_messages_xml"]["paths"]
+        paths = self.config["downloaders"]["read_xml_admin_messages"]["paths"]
 
         # Collect filenames
         fnames = collect_fnames(paths)
-
         tles = []
         for fname in fnames:
             tree = ET.parse(fname)

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -450,7 +450,7 @@ def read_tles_from_mmam_xml_files(paths):
     tles = []
     for fname in fnames:
         data = read_tle_from_mmam_xml_file(fname).split('\n')
-        for two_lines in grouper(2, data):
+        for two_lines in _grouper(2, data):
             tl_stream = io.StringIO('\n'.join(two_lines))
             tles.append(Tle('', tle_file=tl_stream))
     return tles
@@ -467,7 +467,7 @@ def read_tle_from_mmam_xml_file(fname):
     return "\n".join(data)
 
 
-def grouper(n, iterable, fillvalue=None):
+def _grouper(n, iterable, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
     # grouper(3, 'ABCDEFG', 'x') --> ABC DEF Gxx"
     args = [iter(iterable)] * n

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -357,7 +357,9 @@ class Downloader(object):
                 for uri in sources[source]:
                     req = requests.get(uri)
                     if req.status_code == 200:
-                        tles[source] += parse_tles_from_raw_data(req.text)
+                        tles[source] += [
+                            Tle('', tle_file=io.StringIO(tle)) for tle in
+                            _get_tles_from_uris((req.text,), io.StringIO, platform='', only_first=False)]
                     else:
                         failures.append(uri)
                 if len(failures) > 0:
@@ -394,7 +396,9 @@ class Downloader(object):
             req = session.get(download_url)
 
             if req.status_code == 200:
-                tles += parse_tles_from_raw_data(req.text)
+                tles = [
+                    Tle('', tle_file=io.StringIO(tle)) for tle in
+                    _get_tles_from_uris((req.text,), io.StringIO, platform='', only_first=False)]
             else:
                 logging.error("Could not retrieve TLEs from Space-Track")
 

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -347,9 +347,7 @@ class Downloader(object):
                 for uri in sources[source]:
                     req = requests.get(uri)
                     if req.status_code == 200:
-                        tles[source] += [
-                            Tle('', tle_file=io.StringIO(tle)) for tle in
-                            _get_tles_from_uris((req.text,), io.StringIO, platform='', only_first=False)]
+                        tles[source] += _parse_tles_for_downloader((req.text,), io.StringIO)
                     else:
                         failures.append(uri)
                 if len(failures) > 0:
@@ -386,9 +384,7 @@ class Downloader(object):
             req = session.get(download_url)
 
             if req.status_code == 200:
-                tles = [
-                    Tle('', tle_file=io.StringIO(tle)) for tle in
-                    _get_tles_from_uris((req.text,), io.StringIO, platform='', only_first=False)]
+                tles = _parse_tles_for_downloader((req.text,), io.StringIO)
             else:
                 logging.error("Could not retrieve TLEs from Space-Track")
 
@@ -402,11 +398,7 @@ class Downloader(object):
 
         # Collect filenames
         fnames = collect_fnames(paths)
-
-        tles = [
-            Tle('', tle_file=io.StringIO(tle)) for tle in
-            _get_tles_from_uris(fnames, open, platform='', only_first=False)]
-
+        tles = _parse_tles_for_downloader(fnames, open)
         logging.info("Loaded %d TLEs from local files", len(tles))
 
         return tles
@@ -418,6 +410,11 @@ class Downloader(object):
         logging.info("Loaded %d TLEs from admin message XML files", len(tles))
 
         return tles
+
+
+def _parse_tles_for_downloader(item, open_func):
+    return [Tle('', tle_file=io.StringIO(tle)) for tle in
+            _get_tles_from_uris(item, open_func, platform='', only_first=False)]
 
 
 def collect_fnames(paths):

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -474,31 +474,6 @@ def grouper(n, iterable, fillvalue=None):
     return zip_longest(fillvalue=fillvalue, *args)
 
 
-def parse_tles_from_raw_data(raw_data):
-    """Parse TLEs from raw text."""
-    tles = []
-    line1, line2 = None, None
-    raw_data = raw_data.split('\n')
-    for row in raw_data:
-        if row.startswith('1 '):
-            line1 = row
-        elif row.startswith('2 '):
-            line2 = row
-        else:
-            continue
-        if line1 is not None and line2 is not None:
-            try:
-                tle = Tle('', line1=line1, line2=line2)
-            except ValueError:
-                logging.warning(
-                    "Invalid data found - line1: %s, line2: %s",
-                    line1, line2)
-            else:
-                tles.append(tle)
-            line1, line2 = None, None
-    return tles
-
-
 class SQLiteTLE(object):
     """Store TLE data in a sqlite3 database."""
 

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -119,8 +119,6 @@ def fetch(destination):
 class ChecksumError(Exception):
     """ChecksumError."""
 
-    pass
-
 
 class Tle(object):
     """Class holding TLE objects."""

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -437,7 +437,7 @@ def read_tles_from_mmam_xml_files(paths):
     tles = []
     for fname in fnames:
         data = read_tle_from_mmam_xml_file(fname).split('\n')
-        for two_lines in _grouper(2, data):
+        for two_lines in _group_iterable_to_chunks(2, data):
             tl_stream = io.StringIO('\n'.join(two_lines))
             tles.append(Tle('', tle_file=tl_stream))
     return tles
@@ -454,9 +454,9 @@ def read_tle_from_mmam_xml_file(fname):
     return "\n".join(data)
 
 
-def _grouper(n, iterable, fillvalue=None):
+def _group_iterable_to_chunks(n, iterable, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
-    # grouper(3, 'ABCDEFG', 'x') --> ABC DEF Gxx"
+    # _group_iterable_to_chunks(3, 'ABCDEFG', 'x') --> ABC DEF Gxx"
     args = [iter(iterable)] * n
     return zip_longest(fillvalue=fillvalue, *args)
 

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -420,14 +420,20 @@ def read_xml_admin_messages(paths):
     fnames = collect_fnames(paths)
     tles = []
     for fname in fnames:
-        tree = ET.parse(fname)
-        root = tree.getroot()
-        data = []
-        for nav in root.findall(".//navigation"):
-            data.append(nav.find(".//line-1").text)
-            data.append(nav.find(".//line-2").text)
-        tles += parse_tles_from_raw_data("\n".join(data))
+        data = _read_xml_admin_message(fname)
+        tles += parse_tles_from_raw_data(data)
     return tles
+
+
+def _read_xml_admin_message(fname):
+    tree = ET.parse(fname)
+    root = tree.getroot()
+    data = []
+    for nav in root.findall(".//navigation"):
+        data.append(nav.find(".//line-1").text)
+        data.append(nav.find(".//line-2").text)
+
+    return "\n".join(data)
 
 
 def parse_tles_from_raw_data(raw_data):


### PR DESCRIPTION
This PR adds a parser that can read TLE data from MMAM XML files.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
