### PR TITLE
Make `get_observer_look` work on oblate earth

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -122,10 +122,10 @@ def get_observer_look_from_cartesian_position(pos_x, pos_y, pos_z, lon, lat, alt
     sin_theta = np.sin(theta)
     cos_theta = np.cos(theta)
     top_s = sin_lat * cos_theta * rx + \
-            sin_lat * sin_theta * ry - cos_lat * rz
+        sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-            cos_lat * sin_theta * ry + sin_lat * rz
+        cos_lat * sin_theta * ry + sin_lat * rz
     az_ = np.arctan(-top_e / top_s)
 
     if has_xarray and isinstance(az_, xr.DataArray):

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -103,52 +103,49 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = astronomy.observer_position(
         utc_time, sat_lon, sat_lat, sat_alt)
 
+    az_, el_ = get_observer_look_from_cartesian_position(pos_x, pos_y, pos_z, lon, lat, alt, utc_time)
+
+    return az_, el_
+
+
+def get_observer_look_from_cartesian_position(pos_x, pos_y, pos_z, lon, lat, alt, utc_time):
     (opos_x, opos_y, opos_z), (ovel_x, ovel_y, ovel_z) = \
         astronomy.observer_position(utc_time, lon, lat, alt)
-
     lon = np.deg2rad(lon)
     lat = np.deg2rad(lat)
-
     theta = (astronomy.gmst(utc_time) + lon) % (2 * np.pi)
-
     rx = pos_x - opos_x
     ry = pos_y - opos_y
     rz = pos_z - opos_z
-
     sin_lat = np.sin(lat)
     cos_lat = np.cos(lat)
     sin_theta = np.sin(theta)
     cos_theta = np.cos(theta)
-
     top_s = sin_lat * cos_theta * rx + \
-        sin_lat * sin_theta * ry - cos_lat * rz
+            sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-        cos_lat * sin_theta * ry + sin_lat * rz
-
+            cos_lat * sin_theta * ry + sin_lat * rz
     az_ = np.arctan(-top_e / top_s)
 
     if has_xarray and isinstance(az_, xr.DataArray):
         az_data = az_.data
     else:
         az_data = az_
-
     if has_dask and isinstance(az_data, da.Array):
         az_data = da.where(top_s > 0, az_data + np.pi, az_data)
         az_data = da.where(az_data < 0, az_data + 2 * np.pi, az_data)
     else:
-        az_data[np.where(top_s > 0)] += np.pi
-        az_data[np.where(az_data < 0)] += 2 * np.pi
-
+        az_data = np.where(top_s > 0, az_data + np.pi, az_data)
+        az_data = np.where(az_data < 0, az_data + 2 * np.pi, az_data)
     if has_xarray and isinstance(az_, xr.DataArray):
         az_.data = az_data
     else:
         az_ = az_data
-
     rg_ = np.sqrt(rx * rx + ry * ry + rz * rz)
     el_ = np.arcsin(top_z / rg_)
-
-    return np.rad2deg(az_), np.rad2deg(el_)
+    az_, el_ = np.rad2deg(az_), np.rad2deg(el_)
+    return az_, el_
 
 
 class Orbital(object):
@@ -266,38 +263,10 @@ class Orbital(object):
         utc_time = dt2np(utc_time)
         (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = self.get_position(
             utc_time, normalize=False)
-        (opos_x, opos_y, opos_z), (ovel_x, ovel_y, ovel_z) = \
-            astronomy.observer_position(utc_time, lon, lat, alt)
 
-        lon = np.deg2rad(lon)
-        lat = np.deg2rad(lat)
+        az_, el_ = get_observer_look_from_cartesian_position(pos_x, pos_y, pos_z, lon, lat, alt, utc_time)
 
-        theta = (astronomy.gmst(utc_time) + lon) % (2 * np.pi)
-
-        rx = pos_x - opos_x
-        ry = pos_y - opos_y
-        rz = pos_z - opos_z
-
-        sin_lat = np.sin(lat)
-        cos_lat = np.cos(lat)
-        sin_theta = np.sin(theta)
-        cos_theta = np.cos(theta)
-
-        top_s = sin_lat * cos_theta * rx + \
-            sin_lat * sin_theta * ry - cos_lat * rz
-        top_e = -sin_theta * rx + cos_theta * ry
-        top_z = cos_lat * cos_theta * rx + \
-            cos_lat * sin_theta * ry + sin_lat * rz
-
-        az_ = np.arctan(-top_e / top_s)
-
-        az_ = np.where(top_s > 0, az_ + np.pi, az_)
-        az_ = np.where(az_ < 0, az_ + 2 * np.pi, az_)
-
-        rg_ = np.sqrt(rx * rx + ry * ry + rz * rz)
-        el_ = np.arcsin(top_z / rg_)
-
-        return np.rad2deg(az_), np.rad2deg(el_)
+        return az_, el_
 
     def get_orbit_number(self, utc_time, tbus_style=False, as_float=False):
         """Calculate orbit number at specified time.

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -78,10 +78,9 @@ class Test(unittest.TestCase):
         az, el = sat.get_observer_look(d, -84.39733, 33.775867, 0)
         expected_az = 122.45169655331965
         expected_el = 1.9800219611255456
-        self.assertTrue(np.abs(az - expected_az) < eps_deg,
-                        'Calculation of azimut failed')
-        self.assertTrue(np.abs(el - expected_el) < eps_deg,
-                        'Calculation of elevation failed')
+
+        np.testing.assert_allclose(az, expected_az, atol=eps_deg, err_msg='Calculation of azimut failed')
+        np.testing.assert_allclose(el, expected_el, atol=eps_deg, err_msg='Calculation of elevation failed')
 
     def test_orbit_num_an(self):
         sat = orbital.Orbital("METOP-A",


### PR DESCRIPTION
The pyorbital code to compute the observer look was making the assumption that the earth was spherical. While the differences are quite small, we implement here the oblateness of the earth into the function.

 - [ ] Closes #44 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
