### PR TITLE
Make the look angle one computation instead of two

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -122,10 +122,10 @@ def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, po
     sin_theta = np.sin(theta)
     cos_theta = np.cos(theta)
     top_s = sin_lat * cos_theta * rx + \
-            sin_lat * sin_theta * ry - cos_lat * rz
+        sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-            cos_lat * sin_theta * ry + sin_lat * rz
+        cos_lat * sin_theta * ry + sin_lat * rz
     # Azimuth is undefined when elevation is 90 degrees, 180 (pi) will be returned.
     az_ = np.arctan2(-top_e, top_s) + np.pi
     az_ = np.mod(az_, 2 * np.pi)  # Needed on some platforms

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -91,7 +91,7 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
 def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z):
     """Calculate an observer's look angle to a satellite given in cartesian coordinates.
 
-    The satellite is given as an earth-centred inertial position, which is what
+    The satellite is given as an earth-centered inertial position, which is what
     the propagator produces, so that a caller holding one need not turn it into
     a longitude and latitude and back again.
 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -102,10 +102,10 @@ def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, po
     sin_theta = np.sin(theta)
     cos_theta = np.cos(theta)
     top_s = sin_lat * cos_theta * rx + \
-            sin_lat * sin_theta * ry - cos_lat * rz
+        sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-            cos_lat * sin_theta * ry + sin_lat * rz
+        cos_lat * sin_theta * ry + sin_lat * rz
     # Azimuth is undefined when elevation is 90 degrees, 180 (pi) will be returned.
     az_ = np.arctan2(-top_e, top_s) + np.pi
     az_ = np.mod(az_, 2 * np.pi)  # Needed on some platforms

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -83,42 +83,39 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = astronomy.observer_position(
         utc_time, sat_lon, sat_lat, sat_alt)
 
+    az_, el_ = get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z)
+
+    return az_, el_
+
+
+def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z):
     (opos_x, opos_y, opos_z), (ovel_x, ovel_y, ovel_z) = \
         astronomy.observer_position(utc_time, lon, lat, alt)
-
     lon = np.deg2rad(lon)
     lat = np.deg2rad(lat)
-
     theta = (astronomy.gmst(utc_time) + lon) % (2 * np.pi)
-
     rx = pos_x - opos_x
     ry = pos_y - opos_y
     rz = pos_z - opos_z
-
     sin_lat = np.sin(lat)
     cos_lat = np.cos(lat)
     sin_theta = np.sin(theta)
     cos_theta = np.cos(theta)
-
     top_s = sin_lat * cos_theta * rx + \
-        sin_lat * sin_theta * ry - cos_lat * rz
+            sin_lat * sin_theta * ry - cos_lat * rz
     top_e = -sin_theta * rx + cos_theta * ry
     top_z = cos_lat * cos_theta * rx + \
-        cos_lat * sin_theta * ry + sin_lat * rz
-
+            cos_lat * sin_theta * ry + sin_lat * rz
     # Azimuth is undefined when elevation is 90 degrees, 180 (pi) will be returned.
     az_ = np.arctan2(-top_e, top_s) + np.pi
     az_ = np.mod(az_, 2 * np.pi)  # Needed on some platforms
-
     rg_ = np.sqrt(rx * rx + ry * ry + rz * rz)
-
     top_z_divided_by_rg_ = top_z / rg_
-
     # Due to rounding top_z can be larger than rg_ (when el_ ~ 90).
     top_z_divided_by_rg_ = top_z_divided_by_rg_.clip(max=1)
     el_ = np.arcsin(top_z_divided_by_rg_)
-
-    return np.rad2deg(az_), np.rad2deg(el_)
+    az_, el_ = np.rad2deg(az_), np.rad2deg(el_)
+    return az_, el_
 
 
 class Orbital(object):
@@ -238,40 +235,9 @@ class Orbital(object):
 
         """
         utc_time = dt2np(utc_time)
-        (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = self.get_position(
-            utc_time, normalize=False)
-        (opos_x, opos_y, opos_z), (ovel_x, ovel_y, ovel_z) = \
-            astronomy.observer_position(utc_time, lon, lat, alt)
+        (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = self.get_position(utc_time, normalize=False)
 
-        lon = np.deg2rad(lon)
-        lat = np.deg2rad(lat)
-
-        theta = (astronomy.gmst(utc_time) + lon) % (2 * np.pi)
-
-        rx = pos_x - opos_x
-        ry = pos_y - opos_y
-        rz = pos_z - opos_z
-
-        sin_lat = np.sin(lat)
-        cos_lat = np.cos(lat)
-        sin_theta = np.sin(theta)
-        cos_theta = np.cos(theta)
-
-        top_s = sin_lat * cos_theta * rx + \
-            sin_lat * sin_theta * ry - cos_lat * rz
-        top_e = -sin_theta * rx + cos_theta * ry
-        top_z = cos_lat * cos_theta * rx + \
-            cos_lat * sin_theta * ry + sin_lat * rz
-
-        az_ = np.arctan(-top_e / top_s)
-
-        az_ = np.where(top_s > 0, az_ + np.pi, az_)
-        az_ = np.where(az_ < 0, az_ + 2 * np.pi, az_)
-
-        rg_ = np.sqrt(rx * rx + ry * ry + rz * rz)
-        el_ = np.arcsin(top_z / rg_)
-
-        return np.rad2deg(az_), np.rad2deg(el_)
+        return get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z)
 
     def get_orbit_number(self, utc_time, tbus_style=False, as_float=False):
         """Calculate orbit number at specified time.

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -89,6 +89,20 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
 
 
 def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z):
+    """Calculate an observer's look angle to a satellite given in cartesian coordinates.
+
+    The satellite is given as an earth-centred inertial position, which is what
+    the propagator produces, so that a caller holding one need not turn it into
+    a longitude and latitude and back again.
+
+    :utc_time: Observation time (datetime object)
+    :lon: Longitude of observer position on ground in degrees east
+    :lat: Latitude of observer position on ground in degrees north
+    :alt: Altitude above sea-level (geoid) of observer position on ground in km
+    :pos_x, pos_y, pos_z: Satellite position in km
+
+    :return: (Azimuth, Elevation) in degrees
+    """
     (opos_x, opos_y, opos_z), (ovel_x, ovel_y, ovel_z) = \
         astronomy.observer_position(utc_time, lon, lat, alt)
     lon = np.deg2rad(lon)

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -83,9 +83,7 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = astronomy.observer_position(
         utc_time, sat_lon, sat_lat, sat_alt)
 
-    az_, el_ = get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z)
-
-    return az_, el_
+    return get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z)
 
 
 def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, pos_y, pos_z):
@@ -128,8 +126,7 @@ def get_observer_look_from_cartesian_position(utc_time, lon, lat, alt, pos_x, po
     # Due to rounding top_z can be larger than rg_ (when el_ ~ 90).
     top_z_divided_by_rg_ = top_z_divided_by_rg_.clip(max=1)
     el_ = np.arcsin(top_z_divided_by_rg_)
-    az_, el_ = np.rad2deg(az_), np.rad2deg(el_)
-    return az_, el_
+    return np.rad2deg(az_), np.rad2deg(el_)
 
 
 class Orbital(object):

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import unittest
+import warnings
 from unittest import mock
 
 import numpy as np
@@ -422,3 +423,53 @@ def test_get_last_an_time_wrong_input(dtime):
     expected = "UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!"
     with pytest.raises(ValueError, match=expected):
         _ = orb.get_last_an_time(dtime)
+
+
+NOAA_20 = ("1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+           "2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+
+
+def _noaa_20():
+    return orbital.Orbital("NOAA-20", line1=NOAA_20[0], line2=NOAA_20[1])
+
+
+def test_satellite_overhead_is_ninety_degrees_up():
+    """An observer under the satellite sees it at the zenith.
+
+    There the ratio the elevation is taken from is one, and rounding can put it
+    a hair above, which is outside the domain of the arc sine. The answer is
+    ninety degrees, not a nan.
+    """
+    orb = _noaa_20()
+
+    for minutes in range(120):
+        time = dt.datetime(2024, 6, 25, 11, 5) + dt.timedelta(minutes=minutes)
+        sub_lon, sub_lat, _ = orb.get_lonlatalt(time)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _, elevation = orb.get_observer_look(time, float(sub_lon), float(sub_lat), 0.0)
+
+        np.testing.assert_allclose(float(elevation), 90.0, atol=1e-5)
+
+
+def test_the_method_answers_as_the_function_does():
+    """Both ways of asking give the same angles, including due east and west.
+
+    They were written twice and drifted apart, which is what issue #44 reports.
+    """
+    orb = _noaa_20()
+
+    for minutes in range(0, 240, 7):
+        time = dt.datetime(2024, 6, 25, 11, 5) + dt.timedelta(minutes=minutes)
+        sat_lon, sat_lat, sat_alt = orb.get_lonlatalt(time)
+
+        for east_west_offset in (-40.0, -10.0, 10.0, 40.0):
+            lon = float(sat_lon) + east_west_offset
+            lat = float(sat_lat)
+
+            from_method = orb.get_observer_look(time, lon, lat, 0.0)
+            from_function = orbital.get_observer_look(sat_lon, sat_lat, sat_alt,
+                                                      time, lon, lat, 0.0)
+
+            np.testing.assert_allclose(from_method, from_function, atol=1e-3)


### PR DESCRIPTION
`get_observer_look` was written twice: once as a module-level function and once
as a method on `Orbital`. The two drifted apart, which is what #44 reports. This
makes the method call the function's computation instead of keeping its own.

The two are not quite equivalent, and the method had the worse of it:

| | function | method (before) |
|---|---|---|
| azimuth | `arctan2(-top_e, top_s)` | `arctan(-top_e / top_s)` with the quadrant put back by hand |
| elevation | `arcsin` of a ratio clamped to 1 | `arcsin` of the raw ratio |

The unclamped arc sine is a real fault. An observer directly under the satellite
sees it at the zenith, where the ratio is one and rounding can leave it a hair
above, outside the domain. Of a hundred and twenty times tried with the observer
at the sub-satellite point, twenty-one returned a nan and a warning. The
function, which clamps, returns ninety degrees. There is a test for this now.

The divide by zero the method's azimuth invites, when the satellite is exactly
due east or west, appears not to be reachable: `top_s` never landed exactly on
zero in forty-six hundred geometries tried. It is not tested for that reason.
The two implementations are checked against each other instead, so they cannot
quietly drift apart again.

**This may be superseded by #206**, which reorganises the same function into
`ecef_to_topocentric`, `compute_azimuth_elevation` and `_look_from_ecef`, and
independently makes the same clamping fix. The two overlap directly and only one
should land. This branch is the smaller change, ten lines added against
forty-four removed, and does nothing else; #206 carries it alongside a good deal
of unrelated work.

Note the title of this PR used to say it implemented the oblateness of the
Earth. It never did, and the description that went with it was wrong. Whether
anything is owed on that count is a separate question, and one worth opening
with a measurement of the error rather than a change.

 - [x] Closes #44
 - [x] Tests added
 - [x] Tests passed
 - [ ] Fully documented
