### PR TITLE
Add get_observer_look test for scalar case and update stickler config

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,4 @@
 linters:
   flake8:
-    max-line-length: 120
-    fixer: true
-fixers:
-  enable: true
+    python: 3
+    config: setup.cfg

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -298,7 +298,6 @@ class TestGetObserverLook(unittest.TestCase):
         np.testing.assert_allclose(azi.data.compute(), self.exp_azi)
         np.testing.assert_allclose(elev.data.compute(), self.exp_elev)
 
-
     def test_scalar(self):
         """Test with scalar inputs."""
         from pyorbital.orbital import get_observer_look

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -299,6 +299,13 @@ class TestGetObserverLook(unittest.TestCase):
         np.testing.assert_allclose(elev.data.compute(), self.exp_elev)
 
 
+    def test_scalar(self):
+        """Test with scalar inputs."""
+        from pyorbital.orbital import get_observer_look
+        (azi, elev) = get_observer_look(0, 0, 30_000_000, self.t, 0, 0, 0)
+        np.testing.assert_allclose(elev, 90)
+
+
 class TestGetObserverLookNadir(unittest.TestCase):
     """Test the get_observer_look function when satellite is at nadir."""
 


### PR DESCRIPTION
Add a get_observer_look unit test when passing scalars / regular Python types.

Although #90 was a false alarm and had already been fixed in #77, it appears this may have been accidental, as no mention of this bug is made in #77 or #72.  Add a unit test for passing scalars to get_observer_look to make sure we cover this case in the future.

Also updates stickler configuration to make sure it uses Python 3 and respects configuration from `setup.cfg`.

 - [x] Closes #91<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
