### PR TITLE
Update celestrak URIs

### DIFF
--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -38,15 +38,15 @@ from xml.etree import ElementTree as ET
 from itertools import zip_longest
 
 
-TLE_URLS = ('http://www.celestrak.com/NORAD/elements/active.txt',
-            'http://celestrak.com/NORAD/elements/weather.txt',
-            'http://celestrak.com/NORAD/elements/resource.txt',
-            'https://www.celestrak.com/NORAD/elements/cubesat.txt',
-            'http://celestrak.com/NORAD/elements/stations.txt',
-            'https://www.celestrak.com/NORAD/elements/sarsat.txt',
-            'https://www.celestrak.com/NORAD/elements/noaa.txt',
-            'https://www.celestrak.com/NORAD/elements/amateur.txt',
-            'https://www.celestrak.com/NORAD/elements/engineering.txt')
+TLE_URLS = ('https://www.celestrak.org/NORAD/elements/active.txt',
+            'https://celestrak.org/NORAD/elements/weather.txt',
+            'https://celestrak.org/NORAD/elements/resource.txt',
+            'https://www.celestrak.org/NORAD/elements/cubesat.txt',
+            'https://celestrak.org/NORAD/elements/stations.txt',
+            'https://www.celestrak.org/NORAD/elements/sarsat.txt',
+            'https://www.celestrak.org/NORAD/elements/noaa.txt',
+            'https://www.celestrak.org/NORAD/elements/amateur.txt',
+            'https://www.celestrak.org/NORAD/elements/engineering.txt')
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Celestrak is now a non-profit, so the domain has become celestrak.org
rather than celestrak.com.  Update URIs in tlefile.py to account for
this change.  Also change `http://` to `https://` where this wasn't the case
yet.

<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

 - [x] Closes #100 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
