### PR TITLE
Drop direct support of Python <3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setup(name='pyorbital',
       package_data={'pyorbital': [os.path.join('etc', 'platforms.txt')]},
       scripts=['bin/fetch_tles.py', ],
       install_requires=['numpy>=1.19.0', 'scipy', 'requests'],
+      python_requires='>=3.8',
       zip_safe=False,
       )


### PR DESCRIPTION
We don't have any direct incompatibilities currently, but we need to define this sooner rather than later so when we do users are able to download incompatible versions from PyPI.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
