### PR TITLE
www.celestrak.org → celestrak.org

### DIFF
--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -38,15 +38,15 @@ from xml.etree import ElementTree as ET
 from itertools import zip_longest
 
 
-TLE_URLS = ('https://www.celestrak.org/NORAD/elements/active.txt',
+TLE_URLS = ('https://celestrak.org/NORAD/elements/active.txt',
             'https://celestrak.org/NORAD/elements/weather.txt',
             'https://celestrak.org/NORAD/elements/resource.txt',
-            'https://www.celestrak.org/NORAD/elements/cubesat.txt',
+            'https://celestrak.org/NORAD/elements/cubesat.txt',
             'https://celestrak.org/NORAD/elements/stations.txt',
-            'https://www.celestrak.org/NORAD/elements/sarsat.txt',
-            'https://www.celestrak.org/NORAD/elements/noaa.txt',
-            'https://www.celestrak.org/NORAD/elements/amateur.txt',
-            'https://www.celestrak.org/NORAD/elements/engineering.txt')
+            'https://celestrak.org/NORAD/elements/sarsat.txt',
+            'https://celestrak.org/NORAD/elements/noaa.txt',
+            'https://celestrak.org/NORAD/elements/amateur.txt',
+            'https://celestrak.org/NORAD/elements/engineering.txt')
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
After the http→https change in #101, the www. should be dropped as well
to avoid SSL certificate errors/warnings.  Change www.celestrak.org to
celestrak.org for those cases.

See also the post-merge comments on #101.

<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

 - [x] Closes #101 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
