### PR TITLE
Fixed comment in sun_earth_distance_correction

### DIFF
--- a/pyorbital/astronomy.py
+++ b/pyorbital/astronomy.py
@@ -160,7 +160,7 @@ def sun_earth_distance_correction(utc_time):
     #  https://web.archive.org/web/20150117190838/http://curious.astro.cornell.edu/question.php?number=582
     # with
     #  Astronomical unit: AU = 149597870700.0 meter (https://ssd.jpl.nasa.gov/glossary/au.html)
-    #  Semi-major axis:    a = 1.00000261 AU = 1495979097450 m (https://ssd.jpl.nasa.gov/planets/approx_pos.html)
+    #  Semi-major axis:    a = 1.00000261 AU = 149598261150.0 m (https://ssd.jpl.nasa.gov/planets/approx_pos.html)
     #  Eccentricity:       e = 0.01671123 (https://ssd.jpl.nasa.gov/planets/approx_pos.html)
     #  Length of year:  year = 365.25636 days (https://ssd.jpl.nasa.gov/astro_par.html)
     #  Perihelion:         p = 3 (day of year with Earth in perihelion, varies between Jan 2 and Jan 5,


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

This PR fixes an error in the comments of sun_earth_distance_correction in astronomy.py, see [here](https://github.com/pytroll/pyorbital/pull/99#discussion_r917726277) and [here](https://github.com/pytroll/pyorbital/pull/99#discussion_r917809085). In the original comment, the semi-major axis was calculated as $a = 1.00000\mathbf{0}261 \text{ AU}$ and a there was a final zero too much in the actual figure of $a$. Now the comment represents the correct calculation $a = 1.00000261 \text{ AU}$.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
