### PR TITLE
Fix windows test on writing the TLE database

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -30,6 +30,7 @@ import unittest
 from unittest import mock
 import os
 from contextlib import suppress
+import time
 
 line0 = "ISS (ZARYA)"
 line1 = "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927"
@@ -516,6 +517,8 @@ class TestSQLiteTLE(unittest.TestCase):
         # Do not write the satellite name
         self.db.writer_config["write_always"] = True
         self.db.writer_config["write_name"] = False
+        # Wait a bit to ensure different filename
+        time.sleep(2)
         self.db.write_tle_txt()
         files = sorted(glob.glob(os.path.join(tle_dir, 'tle_*txt')))
         self.assertEqual(len(files), 2)


### PR DESCRIPTION
This is an attempt at fixing a failing test on Windows.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
