### PR TITLE
Floating point comparison

### DIFF
--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -118,7 +118,7 @@ class TestGeoloc(unittest.TestCase):
     def test_geodetic_lat(self):
         """Test the determination of the geodetic latitude."""
         point = np.array([7000, 0, 7000])
-        self.assertEqual(geodetic_lat(point), 0.78755832699854733)
+        self.assertAlmostEqual(geodetic_lat(point), 0.78755832699854733)
         points = np.array([[7000, 0, 7000],
                            [7000, 0, 7000]]).T
         self.assertTrue(np.allclose(geodetic_lat(points), np.array([0.78755832699854733, 0.78755832699854733])))


### PR DESCRIPTION
Use `assertAlmostEqual` for floating point comparison.
This fixes a test failure on debian sid.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Tests passed <!-- for all non-documentation changes) -->
 - [X] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
