### PR TITLE
Implement SGDP4_NEAR_SIMP propagation

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -794,8 +794,12 @@ class _SGDP4(object):
         if self.mode == SGDP4_ZERO_ECC:
             raise NotImplementedError('Mode SGDP4_ZERO_ECC not implemented')
         elif self.mode == SGDP4_NEAR_SIMP:
-            raise NotImplementedError('Mode "Near-space, simplified equations"'
-                                      ' not implemented')
+            tempa = 1.0 - ts * self.c1
+            tempe = self.bstar * ts * self.c4
+            templ = ts * ts * self.t2cof
+            a = self.aodp * tempa * tempa
+            e = em - tempe
+            xl = xmp + omega + xnode + self.xnodp * templ
         elif self.mode == SGDP4_NEAR_NORM:
             delm = self.xmcof * \
                 ((1.0 + self.eta * np.cos(xmp))**3 - self.delmo)


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This implements the formula for propagating satellite orbits below 200km until theoretical ground impact.
I adapted this with the C implementation of SGDP4 and compared with Heavensat for satellites which are about to decay naturally, and the results seem to match.

I was having the same issue as #80 when propagating orbits, so now the `NotImplementedError: Mode "Near-space, simplified equations" not implemented` has been implemented.
As a consequence, instead of the `NotImplementedError`, the intended error `Exception('Satellite crashed at time %s', utc_time)` can now be reached when using `Orbital._sgdp4.propagate`.

 - [x] Closes #80  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->

