### PR TITLE
Fix typo in VIIRS geoloc definition

### DIFF
--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -156,7 +156,7 @@ def viirs(scans_nb, scan_indices=slice(0, None),
     """
 
     entire_width = np.arange(chn_pixels)
-    scan_points = entire_width[scan_indices.astype('int')]
+    scan_points = entire_width[scan_indices].astype('int')
     scan_pixels = len(scan_points)
 
     # Initial angle 55.84 deg replaced with 56.28 deg found in

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -190,6 +190,16 @@ class TestGeolocDefs:
         np.testing.assert_allclose(geom.fovs,
                                    expected_fovs, rtol=1e-2, atol=1e-2)
 
+    def test_viirs_defaults(self):
+        """Test the definition of the viirs instrument with default slicing."""
+        geom = viirs(1, chn_pixels=3)
+        expected_fovs = np.array([
+            np.tile(np.array([[0.98, -0., -0.98]]), [32, 1]),
+            np.tile(np.array([[0., -0., 0]]), [32, 1])], dtype=np.float64)
+
+        np.testing.assert_allclose(geom.fovs,
+                                   expected_fovs, rtol=1e-2, atol=1e-2)
+
     def test_amsua(self):
         """Test the definition of the amsua instrument."""
         geom = amsua(1)


### PR DESCRIPTION
This PR fixes a typo in the code for VIIRS geoloc definition.