### PR TITLE
Fix bug getting local tlefiles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
       matrix:
@@ -19,6 +20,7 @@ jobs:
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
+      UNSTABLE: ${{ matrix.experimental }}
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     steps:
@@ -28,22 +30,60 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
+
+      - name: Set cache environment variables
+        shell: bash -l {0}
+        run: |
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          CONDA_PREFIX=$(python -c "import sys; print(sys.prefix)")
+          echo "CONDA_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CONDA_PREFIX }}
+          key: ${{ matrix.os }}-${{matrix.python-version}}-conda-${{ hashFiles('continuous_integration/environment.yaml') }}-${{ env.DATE }}-${{matrix.experimental}}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n test-environment -f continuous_integration/environment.yaml
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Install unstable dependencies
+        if: matrix.experimental == true
+        shell: bash -l {0}
+        # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
+        # may break the conda-forge libraries trying to use newer glibc versions
+        run: |
+          python -m pip install \
+          --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple/ \
+          --trusted-host pypi.anaconda.org \
+          --no-deps --pre --upgrade \
+          matplotlib \
+          numpy \
+          pandas \
+          scipy; \
+          python -m pip install \
+          --no-deps --upgrade \
+          git+https://github.com/dask/dask \
+          git+https://github.com/pydata/xarray \
+          LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
+          echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV
 
       - name: Install Pyorbital
         shell: bash -l {0}
         run: |
-          pip install --no-deps -e .
+          python -m pip install --no-deps -e .
 
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          pytest --cov=pyorbital pyorbital/tests --cov-report=xml
+          export LD_PRELOAD=${{ env.LD_PRELOAD }};
+          pytest --cov=pyorbital pyorbital/tests --cov-report=xml --cov-report=
 
       - name: Upload unittest coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -51,3 +91,27 @@ jobs:
           flags: unittests
           file: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
+
+      - name: Coveralls Parallel
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          flag-name: run-${{ matrix.test_number }}
+          parallel: true
+        if: runner.os == 'Linux'
+
+      - name: Run behaviour tests
+        shell: bash -l {0}
+        run: |
+          export LD_PRELOAD=${{ env.LD_PRELOAD }};
+          coverage run --source=pyorbital --tags=-download
+          coverage xml
+
+
+  coveralls:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
           python -m pip install \
           --no-deps --upgrade \
           git+https://github.com/dask/dask \
-          git+https://github.com/pydata/xarray \
+          git+https://github.com/pydata/xarray;
           LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
           echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  CACHE_NUMBER: 1
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -98,14 +101,6 @@ jobs:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
         if: runner.os == 'Linux'
-
-      - name: Run behaviour tests
-        shell: bash -l {0}
-        run: |
-          export LD_PRELOAD=${{ env.LD_PRELOAD }};
-          coverage run --source=pyorbital --tags=-download
-          coverage xml
-
 
   coveralls:
     needs: [test]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         # may break the conda-forge libraries trying to use newer glibc versions
         run: |
           python -m pip install \
-          --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple/ \
+          --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \
           --no-deps --pre --upgrade \
           matplotlib \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        python-version: ["3.9", "3.10", "3.11"]
+        experimental: [false]
+        include:
+          - python-version: "3.11"
+            os: "ubuntu-latest"
+            experimental: true
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011, 2012, 2013, 2014, 2015.
+# Copyright (c) 2011 - 2023 Pytroll Community
 
 # Author(s):
 
@@ -631,11 +631,11 @@ class _SGDP4(object):
         self.xn_0 = orbit_elements.mean_motion
         # A30 = -XJ3 * AE**3
 
-        if not(0 < self.eo < ECC_LIMIT_HIGH):
+        if not (0 < self.eo < ECC_LIMIT_HIGH):
             raise OrbitalError('Eccentricity out of range: %e' % self.eo)
-        elif not((0.0035 * 2 * np.pi / XMNPDA) < self.xn_0 < (18 * 2 * np.pi / XMNPDA)):
+        elif not ((0.0035 * 2 * np.pi / XMNPDA) < self.xn_0 < (18 * 2 * np.pi / XMNPDA)):
             raise OrbitalError('Mean motion out of range: %e' % self.xn_0)
-        elif not(0 < self.xincl < np.pi):
+        elif not (0 < self.xincl < np.pi):
             raise OrbitalError('Inclination out of range: %e' % self.xincl)
 
         if self.eo < 0:

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011 - 2022 Pytroll Community
+# Copyright (c) 2011 - 2023 Pytroll Community
 
 # Author(s):
 
@@ -55,10 +55,10 @@ def get_results(satnumber, delay):
     path = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(path, "aiaa_results")) as f_2:
         line = f_2.readline()
-        while(line):
+        while line:
             if line.endswith(" xx\n") and int(line[:-3]) == satnumber:
                 line = f_2.readline()
-                while(not line.startswith("%.8f" % delay)):
+                while (not line.startswith("%.8f" % delay)):
                     line = f_2.readline()
                 sline = line.split()
                 if delay == 0:
@@ -94,7 +94,7 @@ class AIAAIntegrationTest(unittest.TestCase):
         path = os.path.dirname(os.path.abspath(__file__))
         with open(os.path.join(path, "SGP4-VER.TLE")) as f__:
             test_line = f__.readline()
-            while(test_line):
+            while test_line:
                 if test_line.startswith("#"):
                     test_name = test_line
                 if test_line.startswith("1 "):

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -99,10 +99,13 @@ def fake_local_tles_dir(tmp_path, monkeypatch):
     """Make a list of fake tle files in a directory."""
     file_path = tmp_path / 'tle-202211180230.txt'
     file_path.touch()
+    time.sleep(1)
     file_path = tmp_path / 'tle-202211180430.txt'
     file_path.touch()
+    time.sleep(1)
     file_path = tmp_path / 'tle-202211180630.txt'
     file_path.touch()
+    time.sleep(1)
     file_path = tmp_path / 'tle-202211180830.txt'
     file_path.touch()
 

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -95,23 +95,22 @@ def fake_platforms_file(tmp_path):
 
 
 @pytest.fixture(scope="session")
-def fake_local_tles_dir(tmp_path, monkeypatch):
+def fake_local_tles_dir(tmp_path_factory):
     """Make a list of fake tle files in a directory."""
-    file_path = tmp_path / 'tle-202211180230.txt'
+    tle_dir = tmp_path_factory.mktemp('tle_files')
+    file_path = tle_dir / 'tle-202211180230.txt'
     file_path.touch()
     time.sleep(1)
-    file_path = tmp_path / 'tle-202211180430.txt'
+    file_path = tle_dir / 'tle-202211180430.txt'
     file_path.touch()
     time.sleep(1)
-    file_path = tmp_path / 'tle-202211180630.txt'
+    file_path = tle_dir / 'tle-202211180630.txt'
     file_path.touch()
     time.sleep(1)
-    file_path = tmp_path / 'tle-202211180830.txt'
+    file_path = tle_dir / 'tle-202211180830.txt'
     file_path.touch()
 
-    monkeypatch.setenv('TLES', str(file_path.parent))
-
-    yield file_path.parent
+    yield tle_dir
 
 
 @pytest.fixture
@@ -271,13 +270,14 @@ def test_get_local_tle_path(mock_env_tles):
     assert res == '/path/to/local/tles'
 
 
-def test_get_uris_and_open_func_using_tles_env(caplog, fake_local_tles_dir):
+def test_get_uris_and_open_func_using_tles_env(caplog, fake_local_tles_dir, monkeypatch):
     """Test getting the uris and associated open-function for reading tles.
 
     Test providing no tle file but using the TLES env to find local tle files.
     """
     from collections.abc import Sequence
 
+    monkeypatch.setenv('TLES', str(fake_local_tles_dir))
     with caplog.at_level(logging.DEBUG):
         uris, _ = _get_uris_and_open_func()
 

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -341,19 +341,6 @@ class TLETest(unittest.TestCase):
         finally:
             remove(filename)
 
-    # def test_from_local_files(self):
-    #     """Test reading and parsing TLEs getting the latest TLE file from a local directory."""
-    #     from tempfile import mkstemp
-    #     from os import write, close, remove
-    #     filehandle, filename = mkstemp()
-    #     try:
-    #         write(filehandle, "\n".join([line0, line1, line2]).encode('utf-8'))
-    #         close(filehandle)
-    #         tle = Tle("NOAA-20", filename)
-    #         self.check_example(tle)
-    #     finally:
-    #         remove(filename)
-
     def test_from_file_with_hyphenated_platform_name(self):
         """Test reading and parsing from a file with a slightly different name."""
         from tempfile import mkstemp

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -94,7 +94,7 @@ def fake_platforms_file(tmp_path):
     yield file_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fake_local_tles_dir(tmp_path, monkeypatch):
     """Make a list of fake tle files in a directory."""
     file_path = tmp_path / 'tle-202211180230.txt'

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -273,10 +273,13 @@ def test_get_uris_and_open_func_using_tles_env(caplog, fake_local_tles_dir):
 
     Test providing no tle file but using the TLES env to find local tle files.
     """
+    from collections.abc import Sequence
+
     with caplog.at_level(logging.DEBUG):
         uris, _ = _get_uris_and_open_func()
 
-    assert uris[0] == str(fake_local_tles_dir)
+    assert isinstance(uris, Sequence)
+    assert uris[0] == str(fake_local_tles_dir / 'tle-202211180830.txt')
     log_message = "Reading TLE from {msg}".format(msg=str(fake_local_tles_dir))
     assert log_message in caplog.text
 
@@ -337,6 +340,19 @@ class TLETest(unittest.TestCase):
             self.check_example(tle)
         finally:
             remove(filename)
+
+    # def test_from_local_files(self):
+    #     """Test reading and parsing TLEs getting the latest TLE file from a local directory."""
+    #     from tempfile import mkstemp
+    #     from os import write, close, remove
+    #     filehandle, filename = mkstemp()
+    #     try:
+    #         write(filehandle, "\n".join([line0, line1, line2]).encode('utf-8'))
+    #         close(filehandle)
+    #         tle = Tle("NOAA-20", filename)
+    #         self.check_example(tle)
+    #     finally:
+    #         remove(filename)
 
     def test_from_file_with_hyphenated_platform_name(self):
         """Test reading and parsing from a file with a slightly different name."""

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -323,8 +323,8 @@ def _get_uris_and_open_func(tle_file=None):
     elif local_tle_path:
         # TODO: get the TLE file closest in time to the actual satellite
         # overpass, NOT the latest!
-        uris = (max(glob.glob(local_tle_path),
-                    key=os.path.getctime), )
+        uris = (max(glob.glob(os.path.join(local_tle_path, '*')),
+                key=os.path.getctime), )
         LOGGER.debug("Reading TLE from %s", uris[0])
         open_func = _open
     else:

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -323,8 +323,8 @@ def _get_uris_and_open_func(tle_file=None):
     elif local_tle_path:
         # TODO: get the TLE file closest in time to the actual satellite
         # overpass, NOT the latest!
-        uris = (max(glob.glob(os.path.join(local_tle_path, '*')),
-                key=os.path.getctime), )
+        list_of_tle_files = glob.glob(os.path.join(local_tle_path, '*'))
+        uris = (max(list_of_tle_files, key=os.path.getctime), )
         LOGGER.debug("Reading TLE from %s", uris[0])
         open_func = _open
     else:

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(name='pyorbital',
       package_data={'pyorbital': [os.path.join('etc', 'platforms.txt')]},
       scripts=['bin/fetch_tles.py', ],
       install_requires=['numpy>=1.19.0', 'scipy', 'requests'],
-      python_requires='>=3.8',
+      python_requires='>=3.9',
       zip_safe=False,
       )


### PR DESCRIPTION
This solves a bug introduced when revising the TLES env variable recently. See #113 . There was a test for this, but it asserted the wrong thing, so test and code was wrong. 

The error arise when specifying a local directory of tle-files via the `TLES` environment variable. The `_get_uris_and_open_func` function wrongly returned the directory path and not the full path of the latest TLE file in that directory.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
