### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,8 @@ sphinx:
   configuration: doc/source/conf.py
   fail_on_warning: true
 
-# conda:
-#     environment: docs/environment.yml
+conda:
+    environment: doc/environment.yaml
 
 python:
     install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: true
+
+# conda:
+#     environment: docs/environment.yml
+
+python:
+    install:
+        - method: pip
+          path: .

--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -1,0 +1,12 @@
+name: readthedocs
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - numpy
+  - scipy
+  - requests
+  - pytest
+  - pyproj
+  - sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,7 @@ from pyorbital import __version__  # noqa
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.coverage']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.coverage', 'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']
@@ -124,7 +124,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['.static']
+html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,8 +1,3 @@
-.. pyorbital documentation master file, created by
-   sphinx-quickstart on Mon Oct  3 08:48:29 2011.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Pyorbital
 =========
 
@@ -92,10 +87,10 @@ specific TLE file is provided or if the :envvar:`TLES` environment variable is n
 
 
 TLE download and database
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The historical TLE files can be requested from
-`celestrak <https://celestrak.com/NORAD/archives/request.php>`_.
+`celestrak's request page <https://celestrak.com/NORAD/archives/request.php>`_.
 
 There is also a script, ``fetch_tles.py``, that can be used to collect
 TLE data from several locations. The currently supported locations
@@ -197,21 +192,21 @@ API
 ---
 
 Orbital computations
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pyorbital.orbital
    :members:
    :undoc-members:
 
 TLE handling
-~~~~~~~~~~~~
+^^^^^^^^^^^^
 
 .. automodule:: pyorbital.tlefile
    :members:
    :undoc-members:
 
 Astronomical computations
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pyorbital.astronomy
    :members:


### PR DESCRIPTION
I got an email that RTD is deprecating a setting and noticed that pyorbital still doesn't have an explicit config which I think is also going to be required soon. This PR adds one.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
