### PR TITLE
Update celestrak urls

### DIFF
--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -37,16 +37,18 @@ import sqlite3
 from xml.etree import ElementTree as ET
 from itertools import zip_longest
 
+TLE_GROUPS = ('active',
+              'weather',
+              'resource',
+              'cubesat',
+              'stations',
+              'sarsat',
+              'noaa',
+              'amateur',
+              'engineering')
 
-TLE_URLS = ('https://celestrak.org/NORAD/elements/active.txt',
-            'https://celestrak.org/NORAD/elements/weather.txt',
-            'https://celestrak.org/NORAD/elements/resource.txt',
-            'https://celestrak.org/NORAD/elements/cubesat.txt',
-            'https://celestrak.org/NORAD/elements/stations.txt',
-            'https://celestrak.org/NORAD/elements/sarsat.txt',
-            'https://celestrak.org/NORAD/elements/noaa.txt',
-            'https://celestrak.org/NORAD/elements/amateur.txt',
-            'https://celestrak.org/NORAD/elements/engineering.txt')
+TLE_URLS = [f'https://celestrak.org/NORAD/elements/gp.php?GROUP={group}&FORMAT=tle'
+            for group in TLE_GROUPS]
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

Celestrak starts to remove the legacy tle txt files. I've detected a 404 error on the active one and asked T.S. Kelso; he points me to [this post](https://twitter.com/TSKelso/status/1740560827378483612) on X. I now suggest to use the query links. 

 - [ ] Closes https://github.com/pytroll/pyorbital/issues/139
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->

