### PR TITLE
Fix a bug in using TLES env variable

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -132,9 +132,9 @@ def mock_env_tles_missing(monkeypatch):
 
 
 @pytest.fixture
-def mock_env_tles(monkeypatch):
+def mock_env_tles(monkeypatch, fake_local_tles_dir):
     """Mock environment variable TLES."""
-    monkeypatch.setenv('TLES', '/path/to/local/tles')
+    monkeypatch.setenv('TLES', os.path.join(fake_local_tles_dir, '*'))
 
 
 def test_get_config_path_no_env_defined(caplog, mock_env_ppp_config_dir_missing):
@@ -264,10 +264,10 @@ def test_get_local_tle_path_tle_env_missing(mock_env_tles_missing):
     assert res is None
 
 
-def test_get_local_tle_path(mock_env_tles):
+def test_get_local_tle_path(mock_env_tles, fake_local_tles_dir):
     """Test getting the path to local TLE files."""
     res = _get_local_tle_path_from_env()
-    assert res == '/path/to/local/tles'
+    assert res == os.path.join(fake_local_tles_dir, "*")
 
 
 def test_get_uris_and_open_func_using_tles_env(caplog, fake_local_tles_dir, monkeypatch):
@@ -277,7 +277,7 @@ def test_get_uris_and_open_func_using_tles_env(caplog, fake_local_tles_dir, monk
     """
     from collections.abc import Sequence
 
-    monkeypatch.setenv('TLES', str(fake_local_tles_dir))
+    monkeypatch.setenv('TLES', str(os.path.join(fake_local_tles_dir, "*")))
     with caplog.at_level(logging.DEBUG):
         uris, _ = _get_uris_and_open_func()
 

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -325,7 +325,7 @@ def _get_uris_and_open_func(tle_file=None):
     elif local_tle_path:
         # TODO: get the TLE file closest in time to the actual satellite
         # overpass, NOT the latest!
-        list_of_tle_files = glob.glob(os.path.join(local_tle_path, '*'))
+        list_of_tle_files = glob.glob(local_tle_path)
         uris = (max(list_of_tle_files, key=os.path.getctime), )
         LOGGER.debug("Reading TLE from %s", uris[0])
         open_func = _open


### PR DESCRIPTION
The behaviour of using `TLES` environment variable was changed in #129. This PR reverts the usage so that `TLES='/path/to/tle_files/tle*txt"` works again.

The question is, should the `TLES=/path/to/tle_files"` introduced in #129 work?

 - [x] Tests adjusted <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
