### PR TITLE
Update `get_next_passes` docstring

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -339,7 +339,7 @@ class Orbital(object):
         :length: Number of hours to find passes (int)
         :lon: Longitude of observer position on ground (float)
         :lat: Latitude of observer position on ground (float)
-        :alt: Altitude above sea-level (geoid) of observer position on ground (float)
+        :alt: Altitude above sea-level (geoid) in km of observer position on ground (float)
         :tol: precision of the result in seconds
         :horizon: the elevation of horizon to compute risetime and falltime.
 


### PR DESCRIPTION
Currently, the documentation for `get_next_passes` is unclear. It does not specify what units should be used for the `altitude`. This PR updates the docstring to make clear that `altitude` should be in km.


 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
