### PR TITLE
Bugfix use of datetime.datetime objects in call to `get_last_an_time`

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2023 Pyorbital developers
+# Copyright (c) 2011-2024 Pyorbital developers
 
 # Author(s):
 
@@ -86,11 +86,14 @@ A3OVK2 = (-XJ3 / CK2) * AE**3
 
 
 class OrbitalError(Exception):
+    """Custom exception for the Orbital class."""
+
     pass
 
 
 def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
     """Calculate observers look angle to a satellite.
+
     http://celestrak.com/columns/v02n02/
 
     :utc_time: Observation time (datetime object)
@@ -142,7 +145,6 @@ def get_observer_look(sat_lon, sat_lat, sat_alt, utc_time, lon, lat, alt):
 
 
 class Orbital(object):
-
     """Class for orbital computations.
 
     The *satellite* parameter is the name of the satellite to work on and is
@@ -151,6 +153,7 @@ class Orbital(object):
     """
 
     def __init__(self, satellite, tle_file=None, line1=None, line2=None):
+        """Initialize the class."""
         satellite = satellite.upper()
         self.satellite_name = satellite
         self.tle = tlefile.read(satellite, tle_file=tle_file,
@@ -159,16 +162,14 @@ class Orbital(object):
         self._sgdp4 = _SGDP4(self.orbit_elements)
 
     def __str__(self):
+        """Print the Orbital object state."""
         return self.satellite_name + " " + str(self.tle)
 
     def get_last_an_time(self, utc_time):
-        """Calculate time of last ascending node relative to the
-        specified time
-        """
-
+        """Calculate time of last ascending node relative to the specified time."""
         # Propagate backwards to ascending node
         dt = np.timedelta64(10, 'm')
-        t_old = utc_time
+        t_old = np.datetime64(utc_time)
         t_new = t_old - dt
         pos0, vel0 = self.get_position(t_old, normalize=False)
         pos1, vel1 = self.get_position(t_new, normalize=False)
@@ -236,14 +237,17 @@ class Orbital(object):
         return np.rad2deg(lon), np.rad2deg(lat), alt
 
     def find_aos(self, utc_time, lon, lat):
+        """Find AOS."""
         pass
 
     def find_aol(self, utc_time, lon, lat):
+        """Find AOL."""
         pass
 
     def get_observer_look(self, utc_time, lon, lat, alt):
         """Calculate observers look angle to a satellite.
-        http://celestrak.com/columns/v02n02/
+
+        See http://celestrak.com/columns/v02n02/
 
         utc_time: Observation time (datetime object)
         lon: Longitude of observer position on ground in degrees east
@@ -251,8 +255,8 @@ class Orbital(object):
         alt: Altitude above sea-level (geoid) of observer position on ground in km
 
         Return: (Azimuth, Elevation)
-        """
 
+        """
         utc_time = dt2np(utc_time)
         (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = self.get_position(
             utc_time, normalize=False)
@@ -330,8 +334,7 @@ class Orbital(object):
         return orbit
 
     def get_next_passes(self, utc_time, length, lon, lat, alt, tol=0.001, horizon=0):
-        """Calculate passes for the next hours for a given start time and a
-        given observer.
+        """Calculate passes for the next hours for a given start time and a given observer.
 
         Original by Martin.
 
@@ -344,8 +347,8 @@ class Orbital(object):
         :horizon: the elevation of horizon to compute risetime and falltime.
 
         :return: [(rise-time, fall-time, max-elevation-time), ...]
-        """
 
+        """
         def elevation(minutes):
             """Compute the elevation."""
             return self.get_observer_look(utc_time +
@@ -358,7 +361,7 @@ class Orbital(object):
             return -elevation(minutes)
 
         def get_root(fun, start, end, tol=0.01):
-            """Root finding scheme"""
+            """Root finding scheme."""
             x_0 = end
             x_1 = start
             fx_0 = fun(end)
@@ -432,15 +435,18 @@ class Orbital(object):
         return res
 
     def _get_time_at_horizon(self, utc_time, obslon, obslat, **kwargs):
-        """Get the time closest in time to *utc_time* when the
-        satellite is at the horizon relative to the position of an observer on
-        ground (altitude = 0)
+        """Determine when the satellite is at the horizon relative to an observer on ground.
+
+        Get the time closest in time to *utc_time* when the satellite is at the
+        horizon relative to the position of an observer on ground (altitude =
+        0).
 
         Note: This is considered deprecated and it's functionality is currently
         replaced by 'get_next_passes'.
+
         """
         warnings.warn("_get_time_at_horizon is replaced with get_next_passes",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         if "precision" in kwargs:
             precision = kwargs['precision']
         else:
@@ -518,7 +524,7 @@ class Orbital(object):
             return None
         elif n_end - n_start > 1:
             warnings.warn('Multiple revolutions between start and end time. Computing crossing '
-                          'time for the last revolution in that interval.')
+                          'time for the last revolution in that interval.', stacklevel=2)
 
         # Let n'(t) = n(t) - offset. Determine offset so that n'(tstart) < 0 and n'(tend) > 0 and
         # n'(tcross) = 0.
@@ -555,11 +561,10 @@ class Orbital(object):
 
 
 class OrbitElements(object):
-
-    """Class holding the orbital elements.
-    """
+    """Class holding the orbital elements."""
 
     def __init__(self, tle):
+        """Initialize the class."""
         self.epoch = tle.epoch
         self.excentricity = tle.excentricity
         self.inclination = np.deg2rad(tle.inclination)
@@ -609,9 +614,7 @@ class OrbitElements(object):
 
 
 class _SGDP4(object):
-
-    """Class for the SGDP4 computations.
-    """
+    """Class for the SGDP4 computations."""
 
     def __init__(self, orbit_elements):
         self.mode = None
@@ -918,6 +921,10 @@ class _SGDP4(object):
 
 
 def kep2xyz(kep):
+    """Keppler to cartesian coordinates conversion.
+
+    (Not sure what 'kep' acttually refers to, just guessing! FIXME!)
+    """
     sinT = np.sin(kep['theta'])
     cosT = np.cos(kep['theta'])
     sinI = np.sin(kep['eqinc'])

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -929,7 +929,7 @@ def _get_tz_unaware_utctime(utc_time):
     """
     if isinstance(utc_time, datetime):
         if utc_time.tzinfo and utc_time.tzinfo != pytz.utc:
-            raise AttributeError("UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!")
+            raise ValueError("UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!")
         return utc_time.replace(tzinfo=None)
 
     return utc_time

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -938,7 +938,7 @@ def _get_tz_unaware_utctime(utc_time):
 def kep2xyz(kep):
     """Keppler to cartesian coordinates conversion.
 
-    (Not sure what 'kep' acttually refers to, just guessing! FIXME!)
+    (Not sure what 'kep' actually refers to, just guessing! FIXME!)
     """
     sinT = np.sin(kep['theta'])
     cosT = np.cos(kep['theta'])

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -927,13 +927,12 @@ def _get_tz_unaware_utctime(utc_time):
     The input *utc_time* is either a timezone unaware object assumed to be in
     UTC, or a timezone aware datetime object in UTC.
     """
-    if not hasattr(utc_time, 'tzinfo') or utc_time.tzinfo is None:
-        return utc_time
+    if isinstance(utc_time, datetime):
+        if utc_time.tzinfo and utc_time.tzinfo != pytz.utc:
+            raise AttributeError("UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!")
+        return utc_time.replace(tzinfo=None)
 
-    if utc_time.tzinfo != pytz.utc:
-        raise AttributeError("UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!")
-
-    return utc_time.replace(tzinfo=None)
+    return utc_time
 
 
 def kep2xyz(kep):

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2014, 2022 Pytroll Community
+# Copyright (c) 2012-2024 Pytroll Community
 
 # Author(s):
 
@@ -20,24 +20,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Test the geoloc orbital.
-"""
+"""Test the geoloc orbital."""
 
+import pytest
 import unittest
 from unittest import mock
 from datetime import datetime, timedelta
-
 import numpy as np
-
 from pyorbital import orbital
 
 eps_deg = 10e-3
 
 
 class Test(unittest.TestCase):
+    """Basic test class for unittesting the pyorbital.orbital class."""
 
     def test_get_orbit_number(self):
-        """Testing getting the orbitnumber from the tle"""
+        """Testing getting the orbitnumber from the TLEs."""
         sat = orbital.Orbital("NPP",
                               line1="1 37849U 11061A   12017.90990040 "
                                     "-.00000112  00000-0 -32693-4 0   772",
@@ -48,6 +47,7 @@ class Test(unittest.TestCase):
         self.assertEqual(orbnum, 1163)
 
     def test_sublonlat(self):
+        """Test getting the sub-satellite position."""
         sat = orbital.Orbital("ISS (ZARYA)",
                               line1="1 25544U 98067A   03097.78853147  "
                                     ".00021906  00000-0  28403-3 0  8652",
@@ -66,6 +66,7 @@ class Test(unittest.TestCase):
                         'Calculation of altitude failed')
 
     def test_observer_look(self):
+        """Test getting the observer look angles."""
         sat = orbital.Orbital("ISS (ZARYA)",
                               line1="1 25544U 98067A   03097.78853147  "
                                     ".00021906  00000-0  28403-3 0  8652",
@@ -81,6 +82,7 @@ class Test(unittest.TestCase):
                         'Calculation of elevation failed')
 
     def test_orbit_num_an(self):
+        """Test getting orbit number - ascending node."""
         sat = orbital.Orbital("METOP-A",
                               line1="1 29499U 06044A   11254.96536486  "
                                     ".00000092  00000-0  62081-4 0  5221",
@@ -90,6 +92,7 @@ class Test(unittest.TestCase):
         self.assertEqual(sat.get_orbit_number(d), 25437)
 
     def test_orbit_num_non_an(self):
+        """Test getting orbit number - not ascending node."""
         sat = orbital.Orbital("METOP-A",
                               line1="1 29499U 06044A   13060.48822809  "
                                     ".00000017  00000-0  27793-4 0  9819",
@@ -99,6 +102,7 @@ class Test(unittest.TestCase):
         self.assertEqual(sat.get_orbit_number(sat.tle.epoch + dt), 33028)
 
     def test_orbit_num_equator(self):
+        """Test getting orbit numbers when being around equator."""
         sat = orbital.Orbital("SUOMI NPP",
                               line1="1 37849U 11061A   13061.24611272  "
                                     ".00000048  00000-0  43679-4 0  4334",
@@ -131,7 +135,7 @@ class Test(unittest.TestCase):
             timedelta(seconds=0.01))
 
     def test_get_next_passes_tricky(self):
-        """ Check issue #34 for reference """
+        """Check issue #34 for reference."""
         line1 = "1 43125U 18004Q   18251.42128650 " \
             "+.00001666 +00000-0 +73564-4 0  9991"
 
@@ -153,7 +157,7 @@ class Test(unittest.TestCase):
         self.assertTrue(len(res) == 15)
 
     def test_get_next_passes_issue_22(self):
-        """Check that max"""
+        """Check that max."""
         line1 = '1 28654U 05018A   21083.16603416  .00000102  00000-0  79268-4 0  9999'
         line2 = '2 28654  99.0035 147.6583 0014816 159.4931 200.6838 14.12591533816498'
 
@@ -166,6 +170,7 @@ class Test(unittest.TestCase):
 
     @mock.patch('pyorbital.orbital.Orbital.get_lonlatalt')
     def test_utc2local(self, get_lonlatalt):
+        """Test converting UTC to local time."""
         get_lonlatalt.return_value = -45, None, None
         sat = orbital.Orbital("METOP-A",
                               line1="1 29499U 06044A   13060.48822809  "
@@ -178,6 +183,7 @@ class Test(unittest.TestCase):
     @mock.patch('pyorbital.orbital.Orbital.utc2local')
     @mock.patch('pyorbital.orbital.Orbital.get_orbit_number')
     def test_get_equatorial_crossing_time(self, get_orbit_number, utc2local):
+        """Test get the equatorial crossing time."""
         def get_orbit_number_patched(utc_time, **kwargs):
             utc_time = np.datetime64(utc_time)
             diff = (utc_time - np.datetime64('2009-07-01 12:38:12')) / np.timedelta64(7200, 's')
@@ -212,9 +218,10 @@ class Test(unittest.TestCase):
 
 
 class TestGetObserverLook(unittest.TestCase):
-    """Test the get_observer_look function"""
+    """Test the get_observer_look function."""
 
     def setUp(self):
+        """Set up the test environment."""
         self.t = datetime(2018, 1, 1, 0, 0, 0)
         self.sat_lon = np.array([[-89.5, -89.4, -89.5, -89.4],
                                  [-89.3, -89.2, -89.3, -89.2]])
@@ -232,7 +239,7 @@ class TestGetObserverLook(unittest.TestCase):
                                   [83.17507167, 90, 66.559906, 81.010018]])
 
     def test_basic_numpy(self):
-        """Test with numpy array inputs"""
+        """Test with numpy array inputs."""
         from pyorbital import orbital
         azi, elev = orbital.get_observer_look(self.sat_lon, self.sat_lat,
                                               self.sat_alt, self.t,
@@ -241,7 +248,7 @@ class TestGetObserverLook(unittest.TestCase):
         np.testing.assert_allclose(elev, self.exp_elev)
 
     def test_basic_dask(self):
-        """Test with dask array inputs"""
+        """Test with dask array inputs."""
         from pyorbital import orbital
         import dask.array as da
         sat_lon = da.from_array(self.sat_lon, chunks=2)
@@ -257,7 +264,7 @@ class TestGetObserverLook(unittest.TestCase):
         np.testing.assert_allclose(elev.compute(), self.exp_elev)
 
     def test_xarray_with_numpy(self):
-        """Test with xarray DataArray with numpy array as inputs"""
+        """Test with xarray DataArray with numpy array as inputs."""
         from pyorbital import orbital
         import xarray as xr
 
@@ -276,7 +283,7 @@ class TestGetObserverLook(unittest.TestCase):
         np.testing.assert_allclose(elev.data, self.exp_elev)
 
     def test_xarray_with_dask(self):
-        """Test with xarray DataArray with dask array as inputs"""
+        """Test with xarray DataArray with dask array as inputs."""
         from pyorbital import orbital
         import dask.array as da
         import xarray as xr
@@ -306,13 +313,14 @@ class TestGetObserverLookNadir(unittest.TestCase):
     """Test the get_observer_look function when satellite is at nadir."""
 
     def setUp(self):
-        """Setup for test observer at nadir.
+        """Set up for test observer at nadir.
+
         Note that rounding error differs between array types.
         With 1000 elements a test gives:
-        1 error for basic numpy
-        41 errors for basic dask
-        63 errors for xarray with dask
-        2 error for xarray with numpy
+          1 error for basic numpy
+          41 errors for basic dask
+          63 errors for xarray with dask
+          2 error for xarray with numpy
         """
         rng = np.random.RandomState(125)
         self.t = datetime(2018, 1, 1, 0, 0, 0)
@@ -325,7 +333,7 @@ class TestGetObserverLookNadir(unittest.TestCase):
         self.exp_elev = np.zeros((100)) + 90
 
     def test_basic_numpy(self):
-        """Test with numpy array inputs"""
+        """Test with numpy array inputs."""
         from pyorbital import orbital
         azi, elev = orbital.get_observer_look(self.sat_lon, self.sat_lat,
                                               self.sat_alt, self.t,
@@ -335,7 +343,7 @@ class TestGetObserverLookNadir(unittest.TestCase):
         np.testing.assert_allclose(elev, self.exp_elev)
 
     def test_basic_dask(self):
-        """Test with dask array inputs"""
+        """Test with dask array inputs."""
         from pyorbital import orbital
         import dask.array as da
         sat_lon = da.from_array(self.sat_lon, chunks=2)
@@ -352,7 +360,7 @@ class TestGetObserverLookNadir(unittest.TestCase):
         np.testing.assert_allclose(elev.compute(), self.exp_elev)
 
     def test_xarray_with_numpy(self):
-        """Test with xarray DataArray with numpy array as inputs"""
+        """Test with xarray DataArray with numpy array as inputs."""
         from pyorbital import orbital
         import xarray as xr
 
@@ -372,7 +380,7 @@ class TestGetObserverLookNadir(unittest.TestCase):
         np.testing.assert_allclose(elev.data, self.exp_elev)
 
     def test_xarray_with_dask(self):
-        """Test with xarray DataArray with dask array as inputs"""
+        """Test with xarray DataArray with dask array as inputs."""
         from pyorbital import orbital
         import dask.array as da
         import xarray as xr
@@ -407,3 +415,23 @@ class TestRegressions(unittest.TestCase):
                       line2="2 37849  98.7092 229.3263 0000715  98.5313 290.6262 14.19554485413345")
         orb.get_next_passes(parser.parse("2019-10-21 16:00:00"), 12, 123.29736, -13.93763, 0)
         warnings.filterwarnings('default')
+
+
+@pytest.mark.parametrize('dtime, expected',
+                         [(datetime(2024, 6, 25, 11, 0, 18),
+                           np.datetime64('2024-06-25T10:44:18.234375')),
+                          (datetime(2024, 6, 25, 11, 5, 0),
+                           np.datetime64('2024-06-25T10:44:18.234375')),
+                          (np.datetime64('2024-06-25T11:10:00.000000'),
+                           np.datetime64('2024-06-25T10:44:18.234375')),
+                          ]
+                         )
+def test_get_last_an_time_scalar_input(dtime, expected):
+    """Test getting the time of the last ascending node - input time is a scalar."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("NOAA-20",
+                  line1='1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014',
+                  line2='2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971')
+
+    result = orb.get_last_an_time(dtime)
+    assert abs(expected - result) < np.timedelta64(1, 's')

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -447,7 +447,7 @@ def test_get_last_an_time_wrong_input(dtime):
                   line1='1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014',
                   line2='2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971')
 
-    with pytest.raises(AttributeError) as exec_info:
+    with pytest.raises(ValueError) as exec_info:
         _ = orb.get_last_an_time(dtime)
 
     expected = "UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!"


### PR DESCRIPTION
Fix so a normal datetime.datetime object can be passed as well to the get last ascending node function.

Currently when running this code below:

```
import pyorbital.orbital
from datetime import datetime

tlefile = "/path/to/some/archived/tle/files/tle-202406250015.txt"

dtobj = datetime(2024, 6, 25, 11, 0, 18)
orb = pyorbital.orbital.Orbital('NOAA-20', tle_file=tlefile)
result = orb.get_last_an_time(dtobj)
```

you will get this kind of error:

```
File <some path>/pyorbital/pyorbital/orbital.py:172, in Orbital.get_last_an_time(self, utc_time)
    170 dt = np.timedelta64(10, 'm')
    171 t_old = utc_time
--> 172 t_new = t_old - dt
    173 pos0, vel0 = self.get_position(t_old, normalize=False)
    174 pos1, vel1 = self.get_position(t_new, normalize=False)

UFuncTypeError: ufunc 'subtract' cannot use operands with types dtype('O') and dtype('<m8[m]')
```

THis PR seeks to solve these kind of errors, allowing to pass a simple `datetime.datetime` object to the function, and not only `numpy.datetime64` objects as seems to have been the case until now.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
