### PR TITLE
Deprecate PPP_CONFIG_DIR for specifying config path

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -183,39 +183,18 @@ def test_check_is_platform_supported_unknown(caplog):
     assert expected3 in logoutput_lines[2]
 
 
-#def test_get_config_path_ppp_config_set_but_not_pyorbital_future(mock, caplog, monkeypatch):
-#    """Test getting the config path."""
-#    monkeypatch.setenv("SATPY_CONFIG_PATH", "/path/to/satpy/etc")
-#    monkeypatch.setenv("PPP_CONFIG_DIR", "/path/to/old/mpop/config/dir")
-#
-#    with caplog.at_level(logging.WARNING):
-#        res = _get_config_path()
-#
-#    log_output = ("The use of PPP_CONFIG_DIR is no longer supported! " +
-#                  "Please use PYORBITAL_CONFIG_PATH if you need a custom config path for pyorbital!")
-#    assert log_output in caplog.text
-#    assert res == PKG_CONFIG_DIR
-
-
-def test_get_config_path_ppp_config_set_but_not_pyorbital_is_deprecated(caplog, monkeypatch):
-    """Test getting the config path.
-
-    Here the case is tested when the new Pyorbital environment variable is not
-    set but the deprecated (old) Satpy/MPOP one is set.
-
-    """
+def test_get_config_path_ppp_config_set_but_not_pyorbital_future(caplog, monkeypatch):
+    """Test getting the config path."""
     monkeypatch.setenv("SATPY_CONFIG_PATH", "/path/to/satpy/etc")
     monkeypatch.setenv("PPP_CONFIG_DIR", "/path/to/old/mpop/config/dir")
 
     with caplog.at_level(logging.WARNING):
         res = _get_config_path()
 
-    assert res == "/path/to/old/mpop/config/dir"
-
-    log_output = ("The use of PPP_CONFIG_DIR is deprecated and will be removed in version 1.9!" +
-                  " Please use PYORBITAL_CONFIG_PATH if you need a custom config path for pyorbital!")
-
+    log_output = ("The use of PPP_CONFIG_DIR is no longer supported! " +
+                  "Please use PYORBITAL_CONFIG_PATH if you need a custom config path for pyorbital!")
     assert log_output in caplog.text
+    assert res == PKG_CONFIG_DIR
 
 
 def test_get_config_path_ppp_config_set_and_pyorbital(caplog, monkeypatch):

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -42,6 +42,7 @@ from pyorbital.tlefile import (
     _get_uris_and_open_func,
     check_is_platform_supported,
     read_platform_numbers,
+    _utcnow,
 )
 
 LINE0 = "ISS (ZARYA)"
@@ -651,7 +652,7 @@ class TestSQLiteTLE(unittest.TestCase):
         assert data[0][1] == "\n".join((LINE1, LINE2))
         # Date when the data were added should be close to current time
         date_added = datetime.datetime.strptime(data[0][2], ISO_TIME_FORMAT)
-        now = datetime.datetime.utcnow()
+        now = _utcnow()
         assert (now - date_added).total_seconds() < 1.0
         # Source of the data
         assert data[0][3] == "foo"

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -41,9 +41,9 @@ from pyorbital.tlefile import (
     _get_config_path,
     _get_local_tle_path_from_env,
     _get_uris_and_open_func,
+    _utcnow,
     check_is_platform_supported,
     read_platform_numbers,
-    _utcnow,
 )
 
 LINE0 = "ISS (ZARYA)"

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -30,6 +30,7 @@ import os
 import time
 import unittest
 from contextlib import suppress
+from tempfile import mkstemp
 from unittest import mock
 
 import pytest
@@ -312,42 +313,36 @@ class TLETest(unittest.TestCase):
 
     def test_from_file(self):
         """Test reading and parsing from a file."""
-        from os import close, remove, write
-        from tempfile import mkstemp
         filehandle, filename = mkstemp()
         try:
-            write(filehandle, "\n".join([LINE0, LINE1, LINE2]).encode("utf-8"))
-            close(filehandle)
+            os.write(filehandle, "\n".join([LINE0, LINE1, LINE2]).encode("utf-8"))
+            os.close(filehandle)
             tle = Tle("ISS (ZARYA)", filename)
             self.check_example(tle)
         finally:
-            remove(filename)
+            os.remove(filename)
 
     def test_from_file_with_hyphenated_platform_name(self):
         """Test reading and parsing from a file with a slightly different name."""
-        from os import close, remove, write
-        from tempfile import mkstemp
         filehandle, filename = mkstemp()
         try:
-            write(filehandle, NOAA19_3LINES.encode("utf-8"))
-            close(filehandle)
+            os.write(filehandle, NOAA19_3LINES.encode("utf-8"))
+            os.close(filehandle)
             tle = Tle("NOAA-19", filename)
             assert tle.satnumber == "33591"
         finally:
-            remove(filename)
+            os.remove(filename)
 
     def test_from_file_with_no_platform_name(self):
         """Test reading and parsing from a file with a slightly different name."""
-        from os import close, remove, write
-        from tempfile import mkstemp
         filehandle, filename = mkstemp()
         try:
-            write(filehandle, NOAA19_2LINES.encode("utf-8"))
-            close(filehandle)
+            os.write(filehandle, NOAA19_2LINES.encode("utf-8"))
+            os.close(filehandle)
             tle = Tle("NOAA-19", filename)
             assert tle.satnumber == "33591"
         finally:
-            remove(filename)
+            os.remove(filename)
 
     def test_from_mmam_xml(self):
         """Test reading from an MMAM XML file."""

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -558,7 +558,7 @@ class SQLiteTLE(object):
         cmd = SATID_VALUES.format(num)
         epoch = tle.epoch.item().isoformat()
         tle = "\n".join([tle.line1, tle.line2])
-        now = dt.datetime.utcnow().isoformat()
+        now = _utcnow().isoformat()
         try:
             with self.db:
                 self.db.execute(cmd, (epoch, tle, now, source))
@@ -575,7 +575,7 @@ class SQLiteTLE(object):
             return
         pattern = os.path.join(self.writer_config["output_dir"],
                                self.writer_config["filename_pattern"])
-        now = dt.datetime.utcnow()
+        now = _utcnow()
         fname = now.strftime(pattern)
         out_dir = os.path.dirname(fname)
         if not os.path.exists(out_dir):
@@ -589,8 +589,7 @@ class SQLiteTLE(object):
             query = f"SELECT epoch, tle FROM '{satid:d}' ORDER BY epoch DESC LIMIT 1"  # nosec
             epoch, tle = self.db.execute(query).fetchone()  # nosec
             date_epoch = dt.datetime.strptime(epoch, ISO_TIME_FORMAT)
-            tle_age = (
-                dt.datetime.utcnow() - date_epoch).total_seconds() / 3600.
+            tle_age = (_utcnow() - date_epoch).total_seconds() / 3600.
             logging.info("Latest TLE for '%s' (%s) is %d hours old.",
                          satid, platform_name, int(tle_age))
             data.append(tle)
@@ -611,6 +610,9 @@ def table_exists(db, name):
     query = "SELECT 1 FROM sqlite_master WHERE type='table' and name=?"
     return db.execute(query, (name,)).fetchone() is not None  # nosec
 
+
+def _utcnow():
+    return dt.datetime.now(tz=dt.timezone.utc).replace(tzinfo=None)
 
 def main():
     """Run a test TLE reading."""

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -63,16 +63,11 @@ class TleDownloadTimeoutError(Exception):
 def _get_config_path():
     """Get the config path for Pyorbital."""
     if "PPP_CONFIG_DIR" in os.environ and "PYORBITAL_CONFIG_PATH" not in os.environ:
-        # XXX: Swap when pyorbital 1.9 is released
-        #LOGGER.warning(
-        #    "The use of PPP_CONFIG_DIR is no longer supported!" +
-        #    " Please use PYORBITAL_CONFIG_PATH if you need a custom config path for pyorbital!")
-        #LOGGER.debug("Using the package default for configuration: %s", PKG_CONFIG_DIR)
-        #return PKG_CONFIG_DIR
         LOGGER.warning(
-            "The use of PPP_CONFIG_DIR is deprecated and will be removed in version 1.9!" +
+            "The use of PPP_CONFIG_DIR is no longer supported!" +
             " Please use PYORBITAL_CONFIG_PATH if you need a custom config path for pyorbital!")
-        pyorbital_config_path = os.getenv("PPP_CONFIG_DIR", PKG_CONFIG_DIR)
+        LOGGER.debug("Using the package default for configuration: %s", PKG_CONFIG_DIR)
+        return PKG_CONFIG_DIR
     else:
         pyorbital_config_path = os.getenv("PYORBITAL_CONFIG_PATH", PKG_CONFIG_DIR)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,10 @@ max-complexity = 10
 [tool.coverage.run]
 relative_files = true
 omit = ["pyorbital/version.py"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,4 +96,3 @@ filterwarnings = [
     "error",
     "ignore:numpy.ndarray size changed:RuntimeWarning",
 ]
-


### PR DESCRIPTION
This is a continuation of #169 to more fully deprecate PPP_CONFIG_DIR.

This may need updating to have it raise an exception completely. Further discussion is needed. Due to the previous deprecation warning, this PR should not be released until 1.9 is ready.

CC @pnuu @mraspaud @adybbroe 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyorbital`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
