### PR TITLE
Update CI build action to work without setup.py

### DIFF
--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -15,7 +15,9 @@ jobs:
 
       - name: Create sdist
         shell: bash -l {0}
-        run: python setup.py sdist
+        run:  |
+          python -m pip install -q build
+          python -m build
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'


### PR DESCRIPTION
In https://github.com/pytroll/pyorbital/pull/169 the `setup.py` was removed, but the CI action to build and deploy the released package was updated. This PR adapts the action to use `python -m build` command.
