### PR TITLE
Remove pytz dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
           - types-setuptools
           - types-PyYAML
           - types-requests
-          - types-pytz
         args: ["--python-version", "3.10", "--ignore-missing-imports"]
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -26,11 +26,10 @@
 
 import logging
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 
 import numpy as np
-import pytz
 from scipy import optimize
 
 from pyorbital import astronomy, dt2np, tlefile
@@ -1230,7 +1229,7 @@ def _get_tz_unaware_utctime(utc_time):
     UTC, or a timezone aware datetime object in UTC.
     """
     if isinstance(utc_time, datetime):
-        if utc_time.tzinfo and utc_time.tzinfo != pytz.utc:
+        if utc_time.tzinfo and utc_time.tzinfo != timezone.utc:
             raise ValueError("UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!")
         return utc_time.replace(tzinfo=None)
 

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -23,12 +23,11 @@
 """Test the geoloc orbital."""
 
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import numpy as np
 import pytest
-import pytz
 
 from pyorbital import orbital
 
@@ -415,7 +414,7 @@ class TestRegressions(unittest.TestCase):
 
 @pytest.mark.parametrize("dtime",
                          [datetime(2024, 6, 25, 11, 0, 18),
-                          datetime(2024, 6, 25, 11, 5, 0, 0, pytz.UTC),
+                          datetime(2024, 6, 25, 11, 5, 0, 0, timezone.utc),
                           np.datetime64("2024-06-25T11:10:00.000000")
                           ]
                          )
@@ -432,7 +431,7 @@ def test_get_last_an_time_scalar_input(dtime):
 
 
 @pytest.mark.parametrize("dtime",
-                         [datetime(2024, 6, 25, 11, 5, 0, 0, pytz.timezone("Europe/Stockholm")),
+                         [datetime(2024, 6, 25, 11, 5, 0, 0, timezone(timedelta(hours=1))),
                           ]
                          )
 def test_get_last_an_time_wrong_input(dtime):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 dependencies = ["numpy>=1.19.0",
                 "scipy",
                 "requests",
-                "pytz",
                 "defusedxml",
                 ]
 readme = "README.md"


### PR DESCRIPTION
Python builtin datetime.timezone serves the same purpose

<!-- Please make the PR against the `main` branch. -->

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
