### PR TITLE
Fix datetime imports

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -114,10 +114,10 @@ Computing satellite position
 The orbital module enables computation of satellite position and velocity at a specific time:
 
     >>> from pyorbital.orbital import Orbital
-    >>> from datetime import datetime
+    >>> import datetime as dt
     >>> # Use current TLEs from the internet:
     >>> orb = Orbital("Suomi NPP")
-    >>> now = datetime.utcnow()
+    >>> now = dt.datetime.now(dt.timezone.utc)
     >>> # Get normalized position and velocity of the satellite:
     >>> orb.get_position(now)
     (array([-0.20015267,  0.09001458,  1.10686756]),
@@ -131,9 +131,9 @@ Use actual TLEs to increase accuracy
 ------------------------------------
 
     >>> from pyorbital.orbital import Orbital
-    >>> from datetime import datetime
+    >>> import datetime as dt
     >>> orb = Orbital("Suomi NPP")
-    >>> dtobj = datetime(2015,2,7,3,0)
+    >>> dtobj = dt.datetime(2015,2,7,3,0)
     >>> orb.get_lonlatalt(dtobj)
     (152.11564698762811, 20.475251739329622, 829.37355785502211)
 
@@ -158,8 +158,8 @@ Computing astronomical parameters
 The astronomy module enables computation of certain parameters of interest for satellite remote sensing for instance the Sun-zenith angle:
 
     >>> from pyorbital import astronomy
-    >>> from datetime import datetime
-    >>> utc_time = datetime(2012, 5, 15, 15, 45)
+    >>> import datetime as dt
+    >>> utc_time = dt.datetime(2012, 5, 15, 15, 45)
     >>> lon, lat = 12, 56
     >>> astronomy.sun_zenith_angle(utc_time, lon, lat)
     62.685986438071602

--- a/pyorbital/geoloc.py
+++ b/pyorbital/geoloc.py
@@ -274,8 +274,8 @@ if __name__ == "__main__":
     noaa18_tle1 = "1 28654U 05018A   11284.35271227  .00000478  00000-0  28778-3 0  9246"
     noaa18_tle2 = "2 28654  99.0096 235.8581 0014859 135.4286 224.8087 14.11526826329313"
 
-    from datetime import datetime
-    t = datetime(2011, 10, 12, 13, 45)
+    import datetime as dt
+    t = dt.datetime(2011, 10, 12, 13, 45)
 
     # edge and centre of an avhrr scanline
     # sgeom = ScanGeometry([(-0.9664123687741623, 0),

--- a/pyorbital/geoloc_example.py
+++ b/pyorbital/geoloc_example.py
@@ -22,7 +22,7 @@
 
 """Simple usage for geoloc."""
 
-from datetime import datetime
+import datetime as dt
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -35,7 +35,7 @@ tle1 = "1 33591U 09005A   12345.45213434  .00000391  00000-0  24004-3 0  6113"
 tle2 = "2 33591 098.8821 283.2036 0013384 242.4835 117.4960 14.11432063197875"
 
 # Choosing a specific time, this should be relatively close to the issue date of the TLE
-t = datetime(2012, 12, 12, 4, 16, 1, 575000)
+t = dt.datetime(2012, 12, 12, 4, 16, 1, 575000)
 # this is the number of full scan rotations
 scans_nb = 10
 # we take only every 40th point for plotting clarity

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -26,9 +26,9 @@
 # TODO: right formal unit tests.
 from __future__ import print_function, with_statement
 
+import datetime as dt
 import os
 import unittest
-from datetime import datetime
 
 import numpy as np
 
@@ -63,7 +63,7 @@ def get_results(satnumber, delay):
                 if delay == 0:
                     utc_time = None
                 else:
-                    utc_time = datetime.strptime(sline[-1], "%H:%M:%S.%f")
+                    utc_time = dt.datetime.strptime(sline[-1], "%H:%M:%S.%f")
                     utc_time = utc_time.replace(year=int(sline[-4]),
                                                 month=int(sline[-3]),
                                                 day=int(sline[-2]))

--- a/pyorbital/tests/test_astronomy.py
+++ b/pyorbital/tests/test_astronomy.py
@@ -23,7 +23,7 @@
 """Unit testing the Astronomy methods and functions."""
 
 
-from datetime import datetime
+import datetime as dt
 
 import dask.array as da
 import numpy as np
@@ -60,16 +60,16 @@ class TestAstronomy:
     """Testing the Astronomy class."""
 
     @pytest.mark.parametrize(
-        ("dt", "exp_jdays", "exp_j2000"),
+        ("dat", "exp_jdays", "exp_j2000"),
         [
-            (datetime(2000, 1, 1, 12, 0), 2451545.0, 0),
-            (datetime(2009, 10, 8, 14, 30), 2455113.1041666665, 3568.1041666666665),
+            (dt.datetime(2000, 1, 1, 12, 0), 2451545.0, 0),
+            (dt.datetime(2009, 10, 8, 14, 30), 2455113.1041666665, 3568.1041666666665),
         ]
     )
-    def test_jdays(self, dt, exp_jdays, exp_j2000):
+    def test_jdays(self, dat, exp_jdays, exp_j2000):
         """Test julian day functions."""
-        assert astr.jdays(dt) == exp_jdays
-        assert astr.jdays2000(dt) == exp_j2000
+        assert astr.jdays(dat) == exp_jdays
+        assert astr.jdays2000(dat) == exp_j2000
 
     @pytest.mark.parametrize(
         ("lon", "lat", "exp_theta"),
@@ -98,7 +98,7 @@ class TestAstronomy:
         if array_construct is None and dtype is not None:
             pytest.skip(reason="Xarray dependency unavailable")
 
-        time_slot = datetime(2011, 9, 23, 12, 0)
+        time_slot = dt.datetime(2011, 9, 23, 12, 0)
         abs_tolerance = 1e-8
         if dtype is not None:
             lon = array_construct([lon], dtype=dtype)
@@ -117,7 +117,7 @@ class TestAstronomy:
 
     def test_sun_earth_distance_correction(self):
         """Test the sun-earth distance correction."""
-        utc_time = datetime(2022, 6, 15, 12, 0, 0)
+        utc_time = dt.datetime(2022, 6, 15, 12, 0, 0)
         corr = astr.sun_earth_distance_correction(utc_time)
         corr_exp = 1.0156952156742332
         assert corr == pytest.approx(corr_exp, abs=1e-8)

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -23,7 +23,7 @@
 """Test the geoloc module."""
 
 
-from datetime import datetime
+import datetime as dt
 
 import numpy as np
 
@@ -108,7 +108,7 @@ class TestGeoloc:
 
         # Test times
 
-        start_of_scan = np.datetime64(datetime(2014, 1, 8, 11, 30))
+        start_of_scan = np.datetime64(dt.datetime(2014, 1, 8, 11, 30))
         times = instrument.times(start_of_scan)
 
         assert times[0, 1] == start_of_scan

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -22,8 +22,8 @@
 
 """Test the geoloc orbital."""
 
+import datetime as dt
 import unittest
-from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import numpy as np
@@ -44,7 +44,7 @@ class Test(unittest.TestCase):
                                     "-.00000112  00000-0 -32693-4 0   772",
                               line2="2 37849  98.7026 317.8811 0001845  "
                                     "92.4533 267.6830 14.19582686 11574")
-        dobj = datetime(2012, 1, 18, 8, 4, 19)
+        dobj = dt.datetime(2012, 1, 18, 8, 4, 19)
         orbnum = sat.get_orbit_number(dobj)
         assert orbnum == 1163
 
@@ -55,7 +55,7 @@ class Test(unittest.TestCase):
                                     ".00021906  00000-0  28403-3 0  8652",
                               line2="2 25544  51.6361  13.7980 0004256  "
                                     "35.6671  59.2566 15.58778559250029")
-        d = datetime(2003, 3, 23, 0, 3, 22)
+        d = dt.datetime(2003, 3, 23, 0, 3, 22)
         lon, lat, alt = sat.get_lonlatalt(d)
         expected_lon = -68.199894472013213
         expected_lat = 23.159747677881075
@@ -71,7 +71,7 @@ class Test(unittest.TestCase):
                                     ".00021906  00000-0  28403-3 0  8652",
                               line2="2 25544  51.6361  13.7980 0004256  "
                                     "35.6671  59.2566 15.58778559250029")
-        d = datetime(2003, 3, 23, 0, 3, 22)
+        d = dt.datetime(2003, 3, 23, 0, 3, 22)
         az, el = sat.get_observer_look(d, -84.39733, 33.775867, 0)
         expected_az = 122.45169655331965
         expected_el = 1.9800219611255456
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
                                     ".00000092  00000-0  62081-4 0  5221",
                               line2="2 29499  98.6804 312.6735 0001758 "
                                     "111.9178 248.2152 14.21501774254058")
-        d = datetime(2011, 9, 14, 5, 30)
+        d = dt.datetime(2011, 9, 14, 5, 30)
         assert sat.get_orbit_number(d) == 25437
 
     def test_orbit_num_non_an(self):
@@ -105,8 +105,8 @@ class Test(unittest.TestCase):
                                     ".00000048  00000-0  43679-4 0  4334",
                               line2="2 37849  98.7444   1.0588 0001264  "
                                     "63.8791 102.8546 14.19528338 69643")
-        t1 = datetime(2013, 3, 2, 22, 2, 25)
-        t2 = datetime(2013, 3, 2, 22, 2, 26)
+        t1 = dt.datetime(2013, 3, 2, 22, 2, 25)
+        t2 = dt.datetime(2013, 3, 2, 22, 2, 26)
         on1 = sat.get_orbit_number(t1)
         on2 = sat.get_orbit_number(t2)
         assert on1 == 6973
@@ -125,9 +125,9 @@ class Test(unittest.TestCase):
                 "89.8714 270.2713 14.34246429 90794"
 
         orb = orbital.Orbital("IRIDIUM 7 [+]", line1=line1, line2=line2)
-        d = datetime(2018, 3, 7, 3, 30, 15)
+        d = dt.datetime(2018, 3, 7, 3, 30, 15)
         res = orb.get_next_passes(d, 1, 170.556, -43.368, 0.5, horizon=40)
-        assert abs(res[0][2] - datetime(2018, 3, 7, 3, 48, 13, 178439)) < timedelta(seconds=0.01)
+        assert abs(res[0][2] - dt.datetime(2018, 3, 7, 3, 48, 13, 178439)) < dt.timedelta(seconds=0.01)
 
     def test_get_next_passes_tricky(self):
         """Check issue #34 for reference."""
@@ -138,12 +138,12 @@ class Test(unittest.TestCase):
             "157.6344 202.5362 15.23132245036381"
 
         orb = orbital.Orbital("LEMUR-2-BROWNCOW", line1=line1, line2=line2)
-        d = datetime(2018, 9, 8)
+        d = dt.datetime(2018, 9, 8)
 
         res = orb.get_next_passes(d, 72, -8.174163, 51.953319, 0.05, horizon=5)
 
-        assert abs(res[0][2] - datetime(2018, 9, 8, 9, 5, 46, 375248)) < timedelta(seconds=0.01)
-        assert abs(res[-1][2] - datetime(2018, 9, 10, 22, 15, 3, 143469)) < timedelta(seconds=0.01)
+        assert abs(res[0][2] - dt.datetime(2018, 9, 8, 9, 5, 46, 375248)) < dt.timedelta(seconds=0.01)
+        assert abs(res[-1][2] - dt.datetime(2018, 9, 10, 22, 15, 3, 143469)) < dt.timedelta(seconds=0.01)
 
         assert len(res) == 15
 
@@ -153,7 +153,7 @@ class Test(unittest.TestCase):
         line2 = "2 28654  99.0035 147.6583 0014816 159.4931 200.6838 14.12591533816498"
 
         orb = orbital.Orbital("NOAA 18", line1=line1, line2=line2)
-        t = datetime(2021, 3, 9, 22)
+        t = dt.datetime(2021, 3, 9, 22)
         next_passes = orb.get_next_passes(t, 1, -15.6335, 27.762, 0.)
         rise, fall, max_elevation = next_passes[0]
         assert rise < max_elevation < fall
@@ -167,7 +167,7 @@ class Test(unittest.TestCase):
                                     ".00000017  00000-0  27793-4 0  9819",
                               line2="2 29499  98.6639 121.6164 0001449  "
                                     "71.9056  43.3132 14.21510544330271")
-        assert sat.utc2local(datetime(2009, 7, 1, 12)) == datetime(2009, 7, 1, 9)
+        assert sat.utc2local(dt.datetime(2009, 7, 1, 12)) == dt.datetime(2009, 7, 1, 9)
 
     @mock.patch("pyorbital.orbital.Orbital.utc2local")
     @mock.patch("pyorbital.orbital.Orbital.get_orbit_number")
@@ -187,21 +187,21 @@ class Test(unittest.TestCase):
                                     "71.9056  43.3132 14.21510544330271")
 
         # Ascending node
-        res = sat.get_equatorial_crossing_time(tstart=datetime(2009, 7, 1, 12),
-                                               tend=datetime(2009, 7, 1, 13))
-        exp = datetime(2009, 7, 1, 12, 38, 12)
-        assert res - exp < timedelta(seconds=0.01)
+        res = sat.get_equatorial_crossing_time(tstart=dt.datetime(2009, 7, 1, 12),
+                                               tend=dt.datetime(2009, 7, 1, 13))
+        exp = dt.datetime(2009, 7, 1, 12, 38, 12)
+        assert res - exp < dt.timedelta(seconds=0.01)
 
         # Descending node
-        res = sat.get_equatorial_crossing_time(tstart=datetime(2009, 7, 1, 12),
-                                               tend=datetime(2009, 7, 1, 14, 0),
+        res = sat.get_equatorial_crossing_time(tstart=dt.datetime(2009, 7, 1, 12),
+                                               tend=dt.datetime(2009, 7, 1, 14, 0),
                                                node="descending")
-        exp = datetime(2009, 7, 1, 13, 38, 12)
-        assert res - exp < timedelta(seconds=0.01)
+        exp = dt.datetime(2009, 7, 1, 13, 38, 12)
+        assert res - exp < dt.timedelta(seconds=0.01)
 
         # Conversion to local time
-        res = sat.get_equatorial_crossing_time(tstart=datetime(2009, 7, 1, 12),
-                                               tend=datetime(2009, 7, 1, 14),
+        res = sat.get_equatorial_crossing_time(tstart=dt.datetime(2009, 7, 1, 12),
+                                               tend=dt.datetime(2009, 7, 1, 14),
                                                local_time=True)
         assert res == "local_time"
 
@@ -211,7 +211,7 @@ class TestGetObserverLook(unittest.TestCase):
 
     def setUp(self):
         """Set up the test environment."""
-        self.t = datetime(2018, 1, 1, 0, 0, 0)
+        self.t = dt.datetime(2018, 1, 1, 0, 0, 0)
         self.sat_lon = np.array([[-89.5, -89.4, -89.5, -89.4],
                                  [-89.3, -89.2, -89.3, -89.2]])
         self.sat_lat = np.array([[45.5, 45.4, 45.5, 45.4],
@@ -315,7 +315,7 @@ class TestGetObserverLookNadir(unittest.TestCase):
           2 error for xarray with numpy
         """
         rng = np.random.RandomState(125)
-        self.t = datetime(2018, 1, 1, 0, 0, 0)
+        self.t = dt.datetime(2018, 1, 1, 0, 0, 0)
         self.sat_lon = 360 * rng.rand(100) - 180
         self.sat_lat = 180 * rng.rand(100) - 90
         self.sat_alt = rng.rand(100) + 850
@@ -408,13 +408,13 @@ class TestRegressions(unittest.TestCase):
         orb = Orbital("Suomi-NPP",
                       line1="1 37849U 11061A   19292.84582509  .00000011  00000-0  25668-4 0  9997",
                       line2="2 37849  98.7092 229.3263 0000715  98.5313 290.6262 14.19554485413345")
-        orb.get_next_passes(datetime(2019, 10, 21, 16, 0, 0), 12, 123.29736, -13.93763, 0)
+        orb.get_next_passes(dt.datetime(2019, 10, 21, 16, 0, 0), 12, 123.29736, -13.93763, 0)
         warnings.filterwarnings("default")
 
 
 @pytest.mark.parametrize("dtime",
-                         [datetime(2024, 6, 25, 11, 0, 18),
-                          datetime(2024, 6, 25, 11, 5, 0, 0, timezone.utc),
+                         [dt.datetime(2024, 6, 25, 11, 0, 18),
+                          dt.datetime(2024, 6, 25, 11, 5, 0, 0, dt.timezone.utc),
                           np.datetime64("2024-06-25T11:10:00.000000")
                           ]
                          )
@@ -431,7 +431,7 @@ def test_get_last_an_time_scalar_input(dtime):
 
 
 @pytest.mark.parametrize("dtime",
-                         [datetime(2024, 6, 25, 11, 5, 0, 0, timezone(timedelta(hours=1))),
+                         [dt.datetime(2024, 6, 25, 11, 5, 0, 0, dt.timezone(dt.timedelta(hours=1))),
                           ]
                          )
 def test_get_last_an_time_wrong_input(dtime):

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -20,7 +20,7 @@
 """Test TLE file reading, TLE downloading and stroging TLEs to database."""
 
 
-import datetime
+import datetime as dt
 import logging
 import os
 import time
@@ -405,8 +405,8 @@ class TLETest(unittest.TestCase):
         assert tle.id_launch_piece.strip() == "A"
         assert tle.epoch_year == "08"
         assert tle.epoch_day == 264.51782528
-        epoch = (datetime.datetime(2008, 1, 1)
-                 + datetime.timedelta(days=264.51782528 - 1))
+        epoch = (dt.datetime(2008, 1, 1)
+                 + dt.timedelta(days=264.51782528 - 1))
         assert tle.epoch == epoch
         assert tle.mean_motion_derivative == -2.182e-05
         assert tle.mean_motion_sec_derivative == 0.0
@@ -774,7 +774,7 @@ class TestSQLiteTLE(unittest.TestCase):
         # TLE
         assert data[0][1] == "\n".join((LINE1, LINE2))
         # Date when the data were added should be close to current time
-        date_added = datetime.datetime.strptime(data[0][2], ISO_TIME_FORMAT)
+        date_added = dt.datetime.strptime(data[0][2], ISO_TIME_FORMAT)
         now = _utcnow()
         assert (now - date_added).total_seconds() < 1.0
         # Source of the data
@@ -786,7 +786,7 @@ class TestSQLiteTLE(unittest.TestCase):
         res = self.db.db.execute(f"select * from '{satid:d}'")  # noseq
         data = res.fetchall()
         assert len(data) == 1
-        date_added2 = datetime.datetime.strptime(data[0][2], ISO_TIME_FORMAT)
+        date_added2 = dt.datetime.strptime(data[0][2], ISO_TIME_FORMAT)
         assert date_added == date_added2
         # Source of the data
         assert data[0][3] == "foo"


### PR DESCRIPTION
As discussed in #175 , it is better to use `import datetime as dt` instead of `from datetime import datetime` so that the module name does not replace the package preventing usage of previously unimported modules. This PR fixes the imports.
