### PR TITLE
Fix avhrr gac geometry

### DIFF
--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -88,9 +88,15 @@ def avhrr_gac(scan_times, scan_points,
     except TypeError:
         offset = np.arange(scan_times) * frequency
     scans_nb = len(offset)
+    # The AVHRR swath is +/- 55.4 degrees, which puts the outermost FOV at
+    #   55.4 * 1023.5 / 1024 = 55.373
+    # GAC pixels are the average of four FOVs with sampling: ..1111.2222.----.NNNN..
+    # so we need to reduce the scan_angle by a factor (1023.5 - 3.5) / 1023.5
+    # to calculate the GAC pixel centres
+    gac_adjust = (1023.5 - 3.5) / 1023.5
 
     avhrr_inst = np.vstack(((scan_points / 204 - 1)
-                            * np.deg2rad(-scan_angle),
+                            * np.deg2rad(-scan_angle * gac_adjust),
                             np.zeros((len(scan_points),))))
 
     avhrr_inst = np.tile(

--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -104,39 +104,6 @@ def avhrr_gac(scan_times, scan_points,
     return ScanGeometry(avhrr_inst, times)
 
 
-def _calc_time_offsets(times):
-    """Convert array of times or offsets to number of seconds as
-    required by ScanGeometry
-
-    :times: Array-like of times or offsets
-    """
-    try:
-        # Convert timedelta to total seconds
-        return np.array([t.total_seconds() for t in times])
-    except (TypeError, AttributeError):
-        pass
-
-    try:
-        # Convert datetime to offset from first element
-        return np.array([(t - times[0]).total_seconds() for t in times])
-    except (TypeError, AttributeError):
-        pass
-
-    # Check for numpy inputs
-    array = np.atleast_1d(times)
-    if array.dtype.kind == 'm':
-        # Convert timedelta64 to float seconds
-        return array / np.timedelta64(1,'s')
-    elif array.dtype.kind == 'M':
-        # Convert datetime64 to offset from first element
-        return (array - array[0]) / np.timedelta64(1,'s')
-    elif array.dtype.kind in 'iuf':
-        # Return integer / float as is
-        return array
-
-    raise TypeError(f'unsupported type for ScanGeometry times: {type(times)}')
-
-
 def avhrr_from_times(scan_times, scan_points, scan_angle=55.37):
     """Definition of the avhrr instrument.
 
@@ -147,7 +114,7 @@ def avhrr_from_times(scan_times, scan_points, scan_angle=55.37):
     :scan_points: Across track pixel positions
     :scan_angle: Maximum scan angle of the outermost FOV
     """
-    offset = _calc_time_offsets(scan_times)
+    offset = np.array([(t - scan_times[0]).total_seconds() for t in scan_times])
     scan_points = np.asanyarray(scan_points)
     scans_nb = len(offset)
 
@@ -171,7 +138,7 @@ def avhrr_gac_from_times(scan_times, scan_points, scan_angle=55.37):
     :scan_points: Across track pixel positions
     :scan_angle: Maximum scan angle of the outermost FOV
     """
-    offset = _calc_time_offsets(scan_times)
+    offset = np.array([(t - scan_times[0]).total_seconds() for t in scan_times])
     scan_points = np.asanyarray(scan_points)
     scans_nb = len(offset)
 

--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -89,14 +89,14 @@ def avhrr_gac(scan_times, scan_points,
         offset = np.arange(scan_times) * frequency
     scans_nb = len(offset)
 
-    avhrr_inst = np.vstack(((scan_points / 1023.5 - 1)
+    avhrr_inst = np.vstack(((scan_points / 204 - 1)
                             * np.deg2rad(-scan_angle),
                             np.zeros((len(scan_points),))))
 
     avhrr_inst = np.tile(
         avhrr_inst[:, np.newaxis, :], [1, np.int32(scans_nb), 1])
     # building the corresponding times array
-    times = (np.tile(scan_points * 0.000025, [scans_nb, 1])
+    times = (np.tile(scan_points * 0.000125, [scans_nb, 1])
              + np.expand_dims(offset, 1))
     return ScanGeometry(avhrr_inst, times)
 

--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -110,7 +110,7 @@ def avhrr_from_times(scan_times, scan_points, scan_angle=55.37):
     Source: NOAA KLM User's Guide, Appendix J
     http://www.ncdc.noaa.gov/oa/pod-guide/ncdc/docs/klm/html/j/app-j.htm
 
-    :scan_times: Observation times or offsets
+    :scan_times: Observation times (datetime object)
     :scan_points: Across track pixel positions
     :scan_angle: Maximum scan angle of the outermost FOV
     """
@@ -134,7 +134,7 @@ def avhrr_gac_from_times(scan_times, scan_points, scan_angle=55.37):
     Source: NOAA KLM User's Guide, Appendix J
     http://www.ncdc.noaa.gov/oa/pod-guide/ncdc/docs/klm/html/j/app-j.htm
 
-    :scan_times: Observation times or offsets
+    :scan_times: Observation times (datetime object)
     :scan_points: Across track pixel positions
     :scan_angle: Maximum scan angle of the outermost FOV
     """

--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -37,6 +37,7 @@ different pixels.
 Both scan angles and scan times are then combined into a ScanGeometry object.
 """
 
+import warnings
 import numpy as np
 
 from pyorbital.geoloc import ScanGeometry
@@ -82,6 +83,8 @@ def avhrr_gac(scan_times, scan_points,
     Source: NOAA KLM User's Guide, Appendix J
     http://www.ncdc.noaa.gov/oa/pod-guide/ncdc/docs/klm/html/j/app-j.htm
     """
+    warnings.warn("avhrr_gac is replaced with avhrr_from_times or avhrr_gac_from_times",
+                  DeprecationWarning)
     try:
         offset = np.array([(t - scan_times[0]).seconds +
                            (t - scan_times[0]).microseconds / 1000000.0 for t in scan_times])
@@ -107,7 +110,6 @@ def _calc_time_offsets(times):
 
     :times: Array-like of times or offsets
     """
-
     try:
         # Convert timedelta to total seconds
         return np.array([t.total_seconds() for t in times])
@@ -145,7 +147,6 @@ def avhrr_from_times(scan_times, scan_points, scan_angle=55.37):
     :scan_points: Across track pixel positions
     :scan_angle: Maximum scan angle of the outermost FOV
     """
-
     offset = _calc_time_offsets(scan_times)
     scan_points = np.asanyarray(scan_points)
     scans_nb = len(offset)
@@ -170,7 +171,6 @@ def avhrr_gac_from_times(scan_times, scan_points, scan_angle=55.37):
     :scan_points: Across track pixel positions
     :scan_angle: Maximum scan angle of the outermost FOV
     """
-
     offset = _calc_time_offsets(scan_times)
     scan_points = np.asanyarray(scan_points)
     scans_nb = len(offset)

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -175,16 +175,16 @@ class TestGeolocDefs:
                                    np.array([[10, 0, -10]]))
 
     def test_avhrr_from_times(self):
-        avh = avhrr_from_times(1, [0, 1023.5, 2047])
+        avh = avhrr_from_times([dt.datetime(2000,1,1,0,0,0)], [0, 1023.5, 2047])
         result = np.rad2deg(avh.fovs[0])
         expected = np.array([[55.37, 0, -55.37]])
         np.testing.assert_allclose(result, expected, rtol=1e-7, atol=1e-7)
         result = avh.times(dt.date(2000,1,1))
         expected = ((np.array([[0, 1023.5, 2047]]) * 25000).astype('timedelta64[ns]')
-                    + np.datetime64('2000-01-01T00:00:01'))
+                    + np.datetime64('2000-01-01T00:00:00'))
         np.testing.assert_equal(result, expected)
 
-        avh = avhrr_from_times(1000, np.array([0, 1023.5, 2047]), 10)
+        avh = avhrr_from_times([dt.datetime(2000,1,1,0,0,0)], np.array([0, 1023.5, 2047]), 10)
         np.testing.assert_allclose(np.rad2deg(avh.fovs[0]),
                                    np.array([[10, 0, -10]]))
 
@@ -197,7 +197,7 @@ class TestGeolocDefs:
 
 
     def test_avhrr_gac_from_times(self):
-        avh = avhrr_gac_from_times(0, [0, 204, 408])
+        avh = avhrr_gac_from_times([dt.datetime(2000,1,1,0,0,0)], [0, 204, 408])
         result = np.rad2deg(avh.fovs[0])
         expected = np.array([[55.180655, 0, -55.180655]])
         np.testing.assert_allclose(result, expected, rtol=1e-7, atol=1e-7)
@@ -206,7 +206,7 @@ class TestGeolocDefs:
                     + np.datetime64('2000-01-01T00:00:00'))
         np.testing.assert_equal(result, expected)
 
-        avh = avhrr_gac_from_times(1000, np.array([0, 204, 408]), 10)
+        avh = avhrr_gac_from_times([dt.datetime(2000,1,1,0,0,0)], np.array([0, 204, 408]), 10)
         np.testing.assert_allclose(np.rad2deg(avh.fovs[0]),
                                    np.array([[9.965804, 0, -9.965804]]))
 

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -168,6 +168,14 @@ class TestGeolocDefs:
         np.testing.assert_allclose(np.rad2deg(avh.fovs[0]),
                                    np.array([[10, 0, -10]]))
 
+        # Check that the avhrr definition will accept scantimes
+        avh = avhrr([dt.datetime(2000,1,1,0,0,0), dt.datetime(2000,1,1,0,1,0)],
+                    np.array([0, 2047]))
+        times = avh.times(dt.datetime(2001,1,1))
+        expected = (np.array([[0,51175000],[60000000000, 60051175000]]).astype('timedelta64[ns]')
+                    + np.datetime64('2001-01-01'))
+        np.testing.assert_equal(times, expected)
+
         # This is perhaps a bit odd, to require avhrr to accept floats for
         # the number of scans? FIXME!
         avh = avhrr(1.1, np.array([0, 1023.5, 2047]), 10)


### PR DESCRIPTION
Updates the avhrr_gac instrument definition to match the across track resolution of AVHRR GAC data.

Previously the definition appears to copy+paste from the full resolution avhrr instrument definition, and did not account for the reduced across track resolution (409 pixels instead of 2048)


 - [x] Closes #184
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
