### PR TITLE
Support yaw arrays for ScanGeometry with same broadcasting as roll / pitch

### DIFF
--- a/pyorbital/geoloc.py
+++ b/pyorbital/geoloc.py
@@ -118,6 +118,9 @@ class ScanGeometry(object):
         # then around y
         xy_rotated = qrotate(x_rotated, y, self.fovs[1] + pitch)
         # then around z
+        if np.shape(yaw):
+            # If we have an array then need to use the same broadcasting as x/y rotation
+            yaw = np.broadcast_to(yaw, self.fovs[0].shape)
         return qrotate(xy_rotated, nadir, yaw)
 
     def times(self, start_of_scan):

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -97,6 +97,14 @@ class TestGeoloc:
         expected = np.array([0.0, 0.0, -1.0])
         np.testing.assert_allclose(result, expected, rtol=1e-8, atol=1e-8)
 
+        # Check if we can pass an array for yaw
+        vec = instrument.vectors(pos, vel, yaw=[0])
+
+        result = vec[:, 0, 1]
+        expected = np.array([0.0, 0.0, -1.0])
+        np.testing.assert_allclose(result, expected, rtol=1e-8, atol=1e-8)
+
+
         # minus sin because we use trigonometrical direction of angles
         result = vec[:, 0, 0]
         expected = np.array([0, -np.sin(np.deg2rad(10)), -np.cos(np.deg2rad(10))])


### PR DESCRIPTION
ScanGeometry.vectors has optional arguments for specifying roll, pitch and yaw rotations.

roll and pitch could already be specified as arrays which would be broadcast with the scan geometry using standard numpy broadcasting rules. However, yaw could only be passed as a scalar (as it was passed through unmodified to qrotate)

This PR adds a simple check to detect an array-like argument for yaw and ensure that it will follow the same broadcast rules already used for the roll and pitch arguments.

 - [x] Tests added
