### PR TITLE
Fix compatibiility with pytest 3.4

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -721,6 +721,7 @@ class TestSQLiteTLE(unittest.TestCase):
         """Clean temporary files."""
         with suppress(PermissionError, NotADirectoryError):
             self.temp_dir.cleanup()
+        self.db.close()
 
     def test_init(self):
         """Test that the init did what it should have."""


### PR DESCRIPTION
Close the sqlite database to avoid warnings that make the tests fail.

<!-- Please make the PR against the `main` branch. -->

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
