### PR TITLE
Move import of tlefile inline to avoid import-time side effects

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -32,7 +32,7 @@ from functools import partial
 import numpy as np
 from scipy import optimize
 
-from pyorbital import astronomy, dt2np, tlefile
+from pyorbital import astronomy, dt2np
 
 try:
     import dask.array as da
@@ -155,6 +155,8 @@ class Orbital(object):
 
     def __init__(self, satellite, tle_file=None, line1=None, line2=None):
         """Initialize the class."""
+        from pyorbital import tlefile
+
         satellite = satellite.upper()
         self.satellite_name = satellite
         self.tle = tlefile.read(satellite, tle_file=tle_file,


### PR DESCRIPTION
Importing `pyorbital.orbital` was importing `tlefile` which was causing config file checking and loading even though much of the functionality in `orbital.py` doesn't use it.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
