### PR TITLE
Extend `OrbitElements` Class with New Methods and Add Pytest Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,8 @@ nosetests.xml
 # rope
 .ropeproject
 
+# Virtual environment
+venv/
+.venv/
+
 pyorbital/version.py

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -648,21 +648,11 @@ class OrbitElements:
 
     def velocity_at_perigee(self):
         """Compute orbital velocity at perigee in km/s."""
-        mu = XKE**2 * AE**3
-        r_p = self.semi_major_axis * (1 - self.excentricity)
-        v_er_per_min = np.sqrt(mu * (1 + self.excentricity) / r_p)
-        # Conversion factor: (AE * XKMPER) converts ER -> km; / 60 converts min -> s
-        conversion_factor = (AE * XKMPER) / 60.0
-        return v_er_per_min * conversion_factor
+        return _get_velocity_at_apsis(1 - self.excentricity, 1 + self.excentricity)
 
     def velocity_at_apogee(self):
         """Compute orbital velocity at apogee in km/s."""
-        mu = XKE**2 * AE**3
-        r_a = self.semi_major_axis * (1 + self.excentricity)
-        v_er_per_min = np.sqrt(mu * (1 - self.excentricity) / r_a)
-        # Conversion factor: (AE * XKMPER) converts ER -> km; / 60 converts min -> s
-        conversion_factor = (AE * XKMPER) / 60.0
-        return v_er_per_min * conversion_factor
+        return _get_velocity_at_apsis(1 + self.excentricity, 1 - self.excentricity)
 
     def _calculate_mean_motion_and_semi_major_axis(self):
         a_1 = (XKE / self.mean_motion) ** (2.0 / 3)

--- a/pyorbital/tests/test_orbit_elements.py
+++ b/pyorbital/tests/test_orbit_elements.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2012-2024 Pytroll Community
+
+# Author(s):
+
+#   Martin Raspaud <martin.raspaud@smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test the orbit orbit elements."""
+
+import datetime
+
+import numpy as np
+import pytest
+
+from pyorbital.orbital import (
+    AE,
+    ECC_EPS,
+    ECC_LIMIT_HIGH,
+    XKMPER,
+    XMNPDA,
+    OrbitElements,
+)
+
+
+class MockTLE:
+    """Mock TLE object for testing OrbitElements."""
+
+    def __init__(self):
+        """Initialize mock TLE values for testing."""
+        self.epoch = datetime.datetime(2025, 9, 30, 12, 0, 0)
+        self.excentricity = 0.001
+        self.inclination = 98.7
+        self.right_ascension = 120.0
+        self.arg_perigee = 87.0
+        self.mean_anomaly = 0.0
+        self.mean_motion = 14.2
+        self.mean_motion_derivative = 0.0
+        self.mean_motion_sec_derivative = 0.0
+        self.bstar = 0.0001
+
+
+def test_orbit_elements_computation():
+    """Test basic orbital element computations (SMA, Period, Angle Range)."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+
+    assert isinstance(orbit.semi_major_axis, float)
+    assert orbit.semi_major_axis > 0
+    assert orbit.period > 0
+    assert -np.pi <= orbit.right_ascension_lon <= np.pi
+
+
+def test_zero_excentricity():
+    """Test perigee calculation with zero eccentricity."""
+    tle = MockTLE()
+    tle.excentricity = 0.0
+    orbit = OrbitElements(tle)
+    # Perigee == Apogee altitude when e=0
+    assert orbit.perigee == pytest.approx(
+        (orbit.semi_major_axis / AE - AE) * XKMPER, abs=1e-3
+    )
+
+
+def test_retrograde_orbit_inclination():
+    """Test basic inclination check for retrograde orbit."""
+    tle = MockTLE()
+    tle.inclination = 120.0
+    orbit = OrbitElements(tle)
+    assert orbit.inclination > np.pi / 2
+
+
+def test_ra_lon_wrapping():
+    """Test longitude wrapping of right ascension with input > 360 deg."""
+    tle = MockTLE()
+    tle.right_ascension = 400.0  # degrees, > 360
+    orbit = OrbitElements(tle)
+    assert -np.pi <= orbit.right_ascension_lon <= np.pi
+
+
+def test_mean_motion_conversion():
+    """Test conversion of mean motion to radians per minute."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    expected = tle.mean_motion * (2 * np.pi / XMNPDA)
+    assert orbit.mean_motion == pytest.approx(expected, rel=1e-6)
+
+
+@pytest.mark.parametrize("incl_deg", [0, 45, 90, 135])
+def test_semi_major_axis_vs_inclination(incl_deg):
+    """Test semi-major axis computation across inclinations."""
+    tle = MockTLE()
+    tle.inclination = incl_deg
+    orbit = OrbitElements(tle)
+    assert orbit.semi_major_axis > 0
+
+
+@pytest.mark.parametrize("bstar", [0.0, 1e-5, 0.0001, 0.01])
+def test_bstar_scaling(bstar):
+    """Test scaling of bstar drag term."""
+    tle = MockTLE()
+    tle.bstar = bstar
+    orbit = OrbitElements(tle)
+    assert orbit.bstar == pytest.approx(bstar * AE)
+
+
+def test_mean_motion_derivatives():
+    """Test mean motion derivatives are correctly computed."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    tle.mean_motion_derivative = 1e-5
+    tle.mean_motion_sec_derivative = 1e-7
+    orbit = OrbitElements(tle)
+    assert orbit.mean_motion_derivative > 0
+    assert orbit.mean_motion_sec_derivative > 0
+
+
+def test_apogee_computation():
+    """Test apogee altitude calculation."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    expected_apogee = (
+        (orbit.semi_major_axis * (1 + orbit.excentricity)) / AE - AE
+    ) * XKMPER
+    assert orbit.apogee == pytest.approx(expected_apogee, abs=1e-3)
+
+
+def test_to_tle_dict_structure():
+    """Test dictionary export of TLE-like orbital elements."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    tle_dict = orbit.to_tle_dict()
+    assert isinstance(tle_dict, dict)
+    expected_keys = {
+        "epoch",
+        "inclination_deg",
+        "right_ascension_deg",
+        "excentricity",
+        "arg_perigee_deg",
+        "mean_anomaly_deg",
+        "mean_motion_rev_per_day",
+        "bstar",
+    }
+    assert expected_keys.issubset(tle_dict.keys())
+
+
+def test_semi_major_axis_accuracy():
+    """Test semi-major axis against analytical reference value (in km)."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    expected_sma_km = 7200.645659667062
+    computed_sma_km = orbit.semi_major_axis * XKMPER / AE
+    assert computed_sma_km == pytest.approx(expected_sma_km, abs=0.1)
+
+
+def test_orbital_period_accuracy():
+    """Test orbital period against corrected mean motion (in seconds)."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    expected_period_sec = 6080.901176943267
+    computed_period_sec = orbit.period * 60
+    assert computed_period_sec == pytest.approx(expected_period_sec, abs=1.0)
+
+
+def test_velocity_at_perigee_accuracy():
+    """Test orbital velocity at perigee against analytical reference."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    expected_velocity_kms = 7.44762253625217
+    computed_velocity_kms = orbit.velocity_at_perigee()
+    assert computed_velocity_kms == pytest.approx(expected_velocity_kms, abs=0.005)
+
+
+def test_velocity_at_apogee_accuracy():
+    """Test orbital velocity at apogee against analytical reference."""
+    tle = MockTLE()
+    orbit = OrbitElements(tle)
+    expected_velocity_kms = 7.432742171544375
+    computed_velocity_kms = orbit.velocity_at_apogee()
+    assert computed_velocity_kms == pytest.approx(expected_velocity_kms, abs=0.005)
+
+
+def test_position_vector_perigee_accuracy():
+    """Test position vector at perigee (Mean Anomaly = 0°)."""
+    tle = MockTLE()
+    tle.excentricity = 0.001
+    tle.mean_anomaly = 0.0
+    orbit = OrbitElements(tle)
+    pos = orbit.position_vector()
+    expected_x = 1.1278289051591721  # Earth radii
+    expected_y = 0.0
+    assert pos[0] == pytest.approx(expected_x, rel=1e-6)
+    assert pos[1] == pytest.approx(expected_y, abs=1e-8)
+
+
+@pytest.mark.parametrize(
+    ("mean_anomaly_deg", "expected_radius"),
+    [
+        (0, 7193.445014007397),
+        (90, 7200.6528603079205),
+        (180, 7207.84630532673),
+        (270, 7200.6528603079205),
+    ],
+)
+def test_position_vector_varied(mean_anomaly_deg, expected_radius):
+    """Verify position vector magnitude matches expected radius at given mean anomaly."""
+    tle = MockTLE()
+    tle.mean_anomaly = mean_anomaly_deg
+    orbit = OrbitElements(tle)
+    pos = orbit.position_vector()
+    actual_radius = np.linalg.norm(pos) * XKMPER
+    assert np.isclose(actual_radius, expected_radius, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("excentricity", "expected"),
+    [
+        (0.0005, True),
+        (0.01, False),
+    ],
+)
+def test_is_circular_property(excentricity, expected):
+    """Test circular orbit detection based on eccentricity."""
+    tle = MockTLE()
+    tle.excentricity = excentricity
+    orbit = OrbitElements(tle)
+    assert orbit.is_circular == expected
+
+
+@pytest.mark.parametrize(
+    ("inclination_deg", "expected"),
+    [
+        (100.0, True),
+        (80.0, False),
+    ],
+)
+def test_is_retrograde_property(inclination_deg, expected):
+    """Test retrograde orbit detection based on inclination."""
+    tle = MockTLE()
+    tle.inclination = inclination_deg
+    orbit = OrbitElements(tle)
+    assert orbit.is_retrograde == expected
+
+
+@pytest.mark.parametrize("excentricity", [0.001, 0.01, 0.1, 0.5])
+def test_velocity_perigee_greater_than_apogee(excentricity):
+    """Ensure velocity at perigee is greater than at apogee for elliptical orbits."""
+    tle = MockTLE()
+    tle.excentricity = excentricity
+    orbit = OrbitElements(tle)
+    v_perigee = orbit.velocity_at_perigee()
+    v_apogee = orbit.velocity_at_apogee()
+    assert v_perigee > v_apogee
+
+
+@pytest.mark.parametrize("excentricity", [0.0, ECC_EPS / 10, ECC_EPS])
+def test_velocity_equal_for_circular_orbits(excentricity):
+    """Ensure velocity at perigee equals velocity at apogee for nearly circular orbits."""
+    tle = MockTLE()
+    tle.excentricity = excentricity
+    orbit = OrbitElements(tle)
+    v_perigee = orbit.velocity_at_perigee()
+    v_apogee = orbit.velocity_at_apogee()
+    assert v_perigee == pytest.approx(v_apogee, rel=1e-5)
+
+
+def test_high_eccentricity_limit():
+    """Test behavior near the upper eccentricity limit."""
+    tle = MockTLE()
+    tle.excentricity = ECC_LIMIT_HIGH
+    orbit = OrbitElements(tle)
+    assert orbit.semi_major_axis > 0
+    assert orbit.velocity_at_perigee() > orbit.velocity_at_apogee()
+
+
+def test_sgp4_unnormalization_value():
+    """Validate SGP4 un-normalization of mean motion and semi-major axis.
+
+    This test uses hardcoded reference values from validated SGP4 output.
+    """
+
+    class RefTLE(MockTLE):
+        """Reference TLE with fixed orbital parameters for precision testing."""
+
+        def __init__(self):
+            super().__init__()
+            """Initialize reference TLE values for SGP4 unnormalization test."""
+            self.inclination = 98.7408  # degrees
+            self.excentricity = 0.001140
+            self.mean_motion = 14.28634842  # rev/day
+            self.epoch = datetime.datetime(2200, 1, 1, 0, 0, 0)
+
+    tle = RefTLE()
+    orbit = OrbitElements(tle)
+
+    # Hardcoded expected values from validated SGP4 propagation
+    expected_mean_motion = 0.06237319306246916  # rad/min
+    expected_semi_major_axis = 1.1244009310620886  # Earth radii
+
+    assert orbit.original_mean_motion == pytest.approx(expected_mean_motion, rel=1e-8)
+    assert orbit.semi_major_axis == pytest.approx(expected_semi_major_axis, rel=1e-8)

--- a/pyorbital/tests/test_orbit_elements.py
+++ b/pyorbital/tests/test_orbit_elements.py
@@ -139,25 +139,6 @@ def test_apogee_computation():
     assert orbit.apogee == pytest.approx(expected_apogee, abs=1e-3)
 
 
-def test_to_tle_dict_structure():
-    """Test dictionary export of TLE-like orbital elements."""
-    tle = MockTLE()
-    orbit = OrbitElements(tle)
-    tle_dict = orbit.to_tle_dict()
-    assert isinstance(tle_dict, dict)
-    expected_keys = {
-        "epoch",
-        "inclination_deg",
-        "right_ascension_deg",
-        "excentricity",
-        "arg_perigee_deg",
-        "mean_anomaly_deg",
-        "mean_motion_rev_per_day",
-        "bstar",
-    }
-    assert expected_keys.issubset(tle_dict.keys())
-
-
 def test_semi_major_axis_accuracy():
     """Test semi-major axis against analytical reference value (in km)."""
     tle = MockTLE()
@@ -194,13 +175,13 @@ def test_velocity_at_apogee_accuracy():
     assert computed_velocity_kms == pytest.approx(expected_velocity_kms, abs=0.005)
 
 
-def test_position_vector_perigee_accuracy():
+def test_position_vector_in_orbital_plane_perigee_accuracy():
     """Test position vector at perigee (Mean Anomaly = 0°)."""
     tle = MockTLE()
     tle.excentricity = 0.001
     tle.mean_anomaly = 0.0
     orbit = OrbitElements(tle)
-    pos = orbit.position_vector()
+    pos = orbit.position_vector_in_orbital_plane()
     expected_x = 1.1278289051591721  # Earth radii
     expected_y = 0.0
     assert pos[0] == pytest.approx(expected_x, rel=1e-6)
@@ -216,12 +197,12 @@ def test_position_vector_perigee_accuracy():
         (270, 7200.6528603079205),
     ],
 )
-def test_position_vector_varied(mean_anomaly_deg, expected_radius):
+def test_position_vector_in_orbital_plane_varied(mean_anomaly_deg, expected_radius):
     """Verify position vector magnitude matches expected radius at given mean anomaly."""
     tle = MockTLE()
     tle.mean_anomaly = mean_anomaly_deg
     orbit = OrbitElements(tle)
-    pos = orbit.position_vector()
+    pos = orbit.position_vector_in_orbital_plane()
     actual_radius = np.linalg.norm(pos) * XKMPER
     assert np.isclose(actual_radius, expected_radius, rtol=1e-6)
 

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -162,7 +162,7 @@ class ChecksumError(Exception):
     """ChecksumError."""
 
 
-class Tle(object):
+class Tle:
     """Class holding TLE objects."""
 
     def __init__(self, platform, tle_file=None, line1=None, line2=None):
@@ -277,6 +277,34 @@ class Tle(object):
         self.mean_anomaly = float(self._line2[43:51])
         self.mean_motion = float(self._line2[52:63])
         self.orbit = int(self._line2[63:68])
+
+    def to_dict(self):
+        """Return the raw, parsed TLE elements as a dictionary."""
+        return {
+            "platform": self.platform,
+            "satnumber": self.satnumber,
+            "classification": self.classification,
+            "id_launch_year": self.id_launch_year,
+            "id_launch_number": self.id_launch_number,
+            "id_launch_piece": self.id_launch_piece,
+            "epoch_year": self.epoch_year,
+            "epoch_day": self.epoch_day,
+            "epoch": self.epoch,
+            "mean_motion_derivative": self.mean_motion_derivative,
+            "mean_motion_sec_derivative": self.mean_motion_sec_derivative,
+            "bstar": self.bstar,
+            "ephemeris_type": self.ephemeris_type,
+            "element_number": self.element_number,
+            "inclination": self.inclination,
+            "right_ascension": self.right_ascension,
+            "excentricity": self.excentricity,
+            "arg_perigee": self.arg_perigee,
+            "mean_anomaly": self.mean_anomaly,
+            "mean_motion": self.mean_motion,
+            "orbit": self.orbit,
+            "line1": self._line1,
+            "line2": self._line2,
+        }
 
     def __str__(self):
         """Format the class data for printing."""


### PR DESCRIPTION
<!-- Please make the PR against the `main` branch. -->

<!-- Describe what your PR does, and why -->

PR improves the `OrbitElements` class by adding several new methods and properties to make it more functional and easier to use. It also introduces a full pytest test suite to verify the correctness of the class (before and after) and its behavior under different conditions.

The changes include:
- new properties: `apogee`, `is_circular`, and `is_retrograde`
- new methods: `position_vector()`, `velocity_at_perigee()`, `velocity_at_apogee()` and `to_tle_dict()`
- a set of unit tests using pytest to cover both the original and new functionality

These additions were made as part of a satellite tracking project where I needed access to derived orbital parameters and a reliable way to validate them. The test suite ensures the class behaves correctly and can be extended in future work.

 - [x] Tests added
 - [x] Fully documented