### PR TITLE
Add fallback when `TLES` environment variable not listing any files

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -394,7 +394,8 @@ def test_get_uris_and_open_func_using_empty_tles_env(caplog, fake_local_tles_dir
     monkeypatch.setenv("TLES", "/no/files/here/tle*txt")
 
     with caplog.at_level(logging.DEBUG):
-        uris, _ = _get_uris_and_open_func()
+        with pytest.warns():
+            uris, _ = _get_uris_and_open_func()
 
     warning_text = "TLES environment variable points to no TLE files"
     debug_text = "Fetch TLE from the internet."

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -24,6 +24,7 @@ import io
 import logging
 import os
 import sqlite3
+import warnings
 from itertools import zip_longest
 from urllib.request import urlopen
 
@@ -332,7 +333,10 @@ def _get_local_uris_and_open_method(local_tle_path):
         open_func = _open
     else:
         LOGGER.warning("TLES environment variable points to no TLE files")
-        LOGGER.warning("TLEs will be downloaded from Celestrack, which can throttle the connection.")
+        throttle_warning = "TLEs will be downloaded from Celestrak, which can throttle the connection."
+        LOGGER.warning(throttle_warning)
+        warnings.warn(throttle_warning)
+
         uris, open_func = _get_internet_uris_and_open_method()
 
     return uris, open_func


### PR DESCRIPTION
Fixes https://github.com/pytroll/pyorbital/issues/74 with a fallback to downloading TLEs from internet.

 - [x] Closes #74  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
