### PR TITLE
Rename 'excentricity' properties to 'eccentricity'

### DIFF
--- a/pyorbital/tests/test_orbit_elements.py
+++ b/pyorbital/tests/test_orbit_elements.py
@@ -43,7 +43,7 @@ class MockTLE:
     def __init__(self):
         """Initialize mock TLE values for testing."""
         self.epoch = datetime.datetime(2025, 9, 30, 12, 0, 0)
-        self.excentricity = 0.001
+        self.eccentricity = 0.001
         self.inclination = 98.7
         self.right_ascension = 120.0
         self.arg_perigee = 87.0
@@ -65,10 +65,10 @@ def test_orbit_elements_computation():
     assert -np.pi <= orbit.right_ascension_lon <= np.pi
 
 
-def test_zero_excentricity():
+def test_zero_eccentricity():
     """Test perigee calculation with zero eccentricity."""
     tle = MockTLE()
-    tle.excentricity = 0.0
+    tle.eccentricity = 0.0
     orbit = OrbitElements(tle)
     # Perigee == Apogee altitude when e=0
     assert orbit.perigee == pytest.approx(
@@ -134,7 +134,7 @@ def test_apogee_computation():
     tle = MockTLE()
     orbit = OrbitElements(tle)
     expected_apogee = (
-        (orbit.semi_major_axis * (1 + orbit.excentricity)) / AE - AE
+        (orbit.semi_major_axis * (1 + orbit.eccentricity)) / AE - AE
     ) * XKMPER
     assert orbit.apogee == pytest.approx(expected_apogee, abs=1e-3)
 
@@ -178,7 +178,7 @@ def test_velocity_at_apogee_accuracy():
 def test_position_vector_in_orbital_plane_perigee_accuracy():
     """Test position vector at perigee (Mean Anomaly = 0°)."""
     tle = MockTLE()
-    tle.excentricity = 0.001
+    tle.eccentricity = 0.001
     tle.mean_anomaly = 0.0
     orbit = OrbitElements(tle)
     pos = orbit.position_vector_in_orbital_plane()
@@ -208,16 +208,16 @@ def test_position_vector_in_orbital_plane_varied(mean_anomaly_deg, expected_radi
 
 
 @pytest.mark.parametrize(
-    ("excentricity", "expected"),
+    ("eccentricity", "expected"),
     [
         (0.0005, True),
         (0.01, False),
     ],
 )
-def test_is_circular_property(excentricity, expected):
+def test_is_circular_property(eccentricity, expected):
     """Test circular orbit detection based on eccentricity."""
     tle = MockTLE()
-    tle.excentricity = excentricity
+    tle.eccentricity = eccentricity
     orbit = OrbitElements(tle)
     assert orbit.is_circular == expected
 
@@ -237,22 +237,22 @@ def test_is_retrograde_property(inclination_deg, expected):
     assert orbit.is_retrograde == expected
 
 
-@pytest.mark.parametrize("excentricity", [0.001, 0.01, 0.1, 0.5])
-def test_velocity_perigee_greater_than_apogee(excentricity):
+@pytest.mark.parametrize("eccentricity", [0.001, 0.01, 0.1, 0.5])
+def test_velocity_perigee_greater_than_apogee(eccentricity):
     """Ensure velocity at perigee is greater than at apogee for elliptical orbits."""
     tle = MockTLE()
-    tle.excentricity = excentricity
+    tle.eccentricity = eccentricity
     orbit = OrbitElements(tle)
     v_perigee = orbit.velocity_at_perigee()
     v_apogee = orbit.velocity_at_apogee()
     assert v_perigee > v_apogee
 
 
-@pytest.mark.parametrize("excentricity", [0.0, ECC_EPS / 10, ECC_EPS])
-def test_velocity_equal_for_circular_orbits(excentricity):
+@pytest.mark.parametrize("eccentricity", [0.0, ECC_EPS / 10, ECC_EPS])
+def test_velocity_equal_for_circular_orbits(eccentricity):
     """Ensure velocity at perigee equals velocity at apogee for nearly circular orbits."""
     tle = MockTLE()
-    tle.excentricity = excentricity
+    tle.eccentricity = eccentricity
     orbit = OrbitElements(tle)
     v_perigee = orbit.velocity_at_perigee()
     v_apogee = orbit.velocity_at_apogee()
@@ -262,7 +262,7 @@ def test_velocity_equal_for_circular_orbits(excentricity):
 def test_high_eccentricity_limit():
     """Test behavior near the upper eccentricity limit."""
     tle = MockTLE()
-    tle.excentricity = ECC_LIMIT_HIGH
+    tle.eccentricity = ECC_LIMIT_HIGH
     orbit = OrbitElements(tle)
     assert orbit.semi_major_axis > 0
     assert orbit.velocity_at_perigee() > orbit.velocity_at_apogee()
@@ -281,7 +281,7 @@ def test_sgp4_unnormalization_value():
             super().__init__()
             """Initialize reference TLE values for SGP4 unnormalization test."""
             self.inclination = 98.7408  # degrees
-            self.excentricity = 0.001140
+            self.eccentricity = 0.001140
             self.mean_motion = 14.28634842  # rev/day
             self.epoch = datetime.datetime(2200, 1, 1, 0, 0, 0)
 

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -437,7 +437,7 @@ class TLETest(unittest.TestCase):
         # line 2
         assert tle.inclination == 51.6416
         assert tle.right_ascension == 247.4627
-        assert tle.excentricity == 0.0006703
+        assert tle.eccentricity == 0.0006703
         assert tle.arg_perigee == 130.536
         assert tle.mean_anomaly == 325.0288
         assert tle.mean_motion == 15.72125391
@@ -877,6 +877,6 @@ def test_tle_instance_printing():
 
     tle = Tle("ISS", line1=LINE1, line2=LINE2)
 
-    expected = "{'arg_perigee': 130.536,\n 'bstar': -1.1606e-05,\n 'classification': 'U',\n 'element_number': 292,\n 'ephemeris_type': 0,\n 'epoch': np.datetime64('2008-09-20T12:25:40.104192'),\n 'epoch_day': 264.51782528,\n 'epoch_year': '08',\n 'excentricity': 0.0006703,\n 'id_launch_number': '067',\n 'id_launch_piece': 'A  ',\n 'id_launch_year': '98',\n 'inclination': 51.6416,\n 'mean_anomaly': 325.0288,\n 'mean_motion': 15.72125391,\n 'mean_motion_derivative': -2.182e-05,\n 'mean_motion_sec_derivative': 0.0,\n 'orbit': 56353,\n 'right_ascension': 247.4627,\n 'satnumber': '25544'}"  # noqa
+    expected = "{'arg_perigee': 130.536,\n 'bstar': -1.1606e-05,\n 'classification': 'U',\n 'eccentricity': 0.0006703,\n 'element_number': 292,\n 'ephemeris_type': 0,\n 'epoch': np.datetime64('2008-09-20T12:25:40.104192'),\n 'epoch_day': 264.51782528,\n 'epoch_year': '08',\n 'id_launch_number': '067',\n 'id_launch_piece': 'A  ',\n 'id_launch_year': '98',\n 'inclination': 51.6416,\n 'mean_anomaly': 325.0288,\n 'mean_motion': 15.72125391,\n 'mean_motion_derivative': -2.182e-05,\n 'mean_motion_sec_derivative': 0.0,\n 'orbit': 56353,\n 'right_ascension': 247.4627,\n 'satnumber': '25544'}"  # noqa
 
     assert str(tle) == expected

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -190,7 +190,7 @@ class Tle:
         self.element_number = None
         self.inclination = None
         self.right_ascension = None
-        self.excentricity = None
+        self.eccentricity = None
         self.arg_perigee = None
         self.mean_anomaly = None
         self.mean_motion = None
@@ -199,6 +199,12 @@ class Tle:
         self._read_tle()
         self._checksum()
         self._parse_tle()
+
+    @property
+    def excentricity(self):
+        """Get 'eccentricity' using legacy 'excentricity' name."""
+        warnings.warn("The 'eccentricity' property is deprecated in favor of 'eccentricity'", stacklevel=2)
+        return self.eccentricity
 
     @property
     def line1(self):
@@ -275,7 +281,7 @@ class Tle:
 
         self.inclination = float(self._line2[8:16])
         self.right_ascension = float(self._line2[17:25])
-        self.excentricity = int(self._line2[26:33]) * 10 ** -7
+        self.eccentricity = int(self._line2[26:33]) * 10 ** -7
         self.arg_perigee = float(self._line2[34:42])
         self.mean_anomaly = float(self._line2[43:51])
         self.mean_motion = float(self._line2[52:63])
@@ -300,7 +306,7 @@ class Tle:
             "element_number": self.element_number,
             "inclination": self.inclination,
             "right_ascension": self.right_ascension,
-            "excentricity": self.excentricity,
+            "eccentricity": self.eccentricity,
             "arg_perigee": self.arg_perigee,
             "mean_anomaly": self.mean_anomaly,
             "mean_motion": self.mean_motion,


### PR DESCRIPTION
According to https://en.wiktionary.org/wiki/excentricity "excentricity" is the "Archaic form of eccentricity. This PR renames the properties in the two locations in pyorbital that use it. Everything should be backwards compatible *except*:

* `__str__` now uses the new name
* `to_dict` now uses the new name

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
