### PR TITLE
Bugfix `Downloader` handling of trailing empty lines

### DIFF
--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -648,11 +648,18 @@ class TestDownloader:
         assert res[0].line1 == LINE1
         assert res[0].line2 == LINE2
 
-    def test_read_tle_files(self):
+    @pytest.mark.parametrize(
+        "tle_lines", [(LINE1, LINE2),
+                      (LINE1, LINE2, ""),
+                      (LINE0, LINE1, LINE2),
+                      (LINE0, LINE1, LINE2, ""),
+                      ]
+    )
+    def test_read_tle_files(self, tle_lines):
         """Test reading TLE files from a file system."""
         from tempfile import TemporaryDirectory
 
-        tle_text = "\n".join((LINE0, LINE1, LINE2))
+        tle_text = "\n".join(tle_lines)
 
         save_dir = TemporaryDirectory()
         with save_dir:

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -499,10 +499,10 @@ FETCH_SPACETRACK_CONFIG = {
 }
 
 
-class TestDownloader(unittest.TestCase):
+class TestDownloader:
     """Test TLE downloader."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create a downloader instance."""
         from pyorbital.tlefile import Downloader
         self.config = {}

--- a/pyorbital/tests/test_tlefile.py
+++ b/pyorbital/tests/test_tlefile.py
@@ -651,8 +651,10 @@ class TestDownloader:
     @pytest.mark.parametrize(
         "tle_lines", [(LINE1, LINE2),
                       (LINE1, LINE2, ""),
+                      (LINE1, LINE2, "", ""),
                       (LINE0, LINE1, LINE2),
                       (LINE0, LINE1, LINE2, ""),
+                      (LINE0, LINE1, LINE2, "", ""),
                       ]
     )
     def test_read_tle_files(self, tle_lines):

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -416,19 +416,39 @@ def _decode_lines(fid, l_0, platform, only_first, open_is_dummy=False):
     tle = ""
     l_0 = _decode(l_0)
     if l_0.strip() == platform:
+        tle = _decode_lines_with_platform_header(fid)
+    elif l_0.strip().startswith(designator):
+        tle = _decode_lines_without_platform_header(fid, l_0, platform, only_first, open_is_dummy)
+    elif l_0.startswith(platform) and platform not in SATELLITES:
+        LOGGER.debug("Found a possible match: %s?", str(l_0.strip()))
+
+    return tle
+
+
+def _decode_lines_with_platform_header(fid):
+    tle = ""
+    try:
         l_1 = _decode(next(fid))
         l_2 = _decode(next(fid))
         tle = _merge_tle_from_two_lines(l_1, l_2)
-    elif l_0.strip().startswith(designator):
-        if (platform in SATELLITES or not only_first) or open_is_dummy:
-            l_1 = l_0
+    except StopIteration:
+        # There were empty lines at the end of the file
+        pass
+    return tle
+
+
+def _decode_lines_without_platform_header(fid, l_0, platform, only_first, open_is_dummy):
+    tle = ""
+    if (platform in SATELLITES or not only_first) or open_is_dummy:
+        l_1 = l_0
+        try:
             l_2 = _decode(next(fid))
             tle = _merge_tle_from_two_lines(l_1, l_2)
             if platform:
                 LOGGER.debug("Found platform %s, ID: %s", platform, SATELLITES[platform])
-    elif l_0.startswith(platform) and platform not in SATELLITES:
-        LOGGER.debug("Found a possible match: %s?", str(l_0.strip()))
-
+        except StopIteration:
+            # There were empty lines at the end of the file
+            pass
     return tle
 
 

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -433,6 +433,7 @@ def _decode_lines_with_platform_header(fid):
 
 
 def _decode_lines_without_platform_header(fid, l_0, platform, only_first, open_is_dummy):
+    tle = ""
     if (platform in SATELLITES or not only_first) or open_is_dummy:
         l_1 = l_0
         l_2 = _decode(next(fid))

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -415,7 +415,7 @@ def _decode_lines(fid, l_0, platform, only_first, open_is_dummy=False):
     designator = "1 " + SATELLITES.get(platform, "")
     tle = ""
     l_0 = _decode(l_0)
-    if l_0.strip() == platform:
+    if l_0.strip() == platform and platform != "":
         tle = _decode_lines_with_platform_header(fid)
     elif l_0.strip().startswith(designator):
         tle = _decode_lines_without_platform_header(fid, l_0, platform, only_first, open_is_dummy)
@@ -426,29 +426,19 @@ def _decode_lines(fid, l_0, platform, only_first, open_is_dummy=False):
 
 
 def _decode_lines_with_platform_header(fid):
-    tle = ""
-    try:
-        l_1 = _decode(next(fid))
-        l_2 = _decode(next(fid))
-        tle = _merge_tle_from_two_lines(l_1, l_2)
-    except StopIteration:
-        # There were empty lines at the end of the file
-        pass
+    l_1 = _decode(next(fid))
+    l_2 = _decode(next(fid))
+    tle = _merge_tle_from_two_lines(l_1, l_2)
     return tle
 
 
 def _decode_lines_without_platform_header(fid, l_0, platform, only_first, open_is_dummy):
-    tle = ""
     if (platform in SATELLITES or not only_first) or open_is_dummy:
         l_1 = l_0
-        try:
-            l_2 = _decode(next(fid))
-            tle = _merge_tle_from_two_lines(l_1, l_2)
-            if platform:
-                LOGGER.debug("Found platform %s, ID: %s", platform, SATELLITES[platform])
-        except StopIteration:
-            # There were empty lines at the end of the file
-            pass
+        l_2 = _decode(next(fid))
+        tle = _merge_tle_from_two_lines(l_1, l_2)
+        if platform:
+            LOGGER.debug("Found platform %s, ID: %s", platform, SATELLITES[platform])
     return tle
 
 


### PR DESCRIPTION
I noticed that if there are any empty lines after the TLEs in files stored locally and used in forming the final TLE set, the parsing fails. This PR adds error handling for the empty lines.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
