### PR TITLE
Fix sun_zenith_angle on integer lon/lat (crash + silent truncation)

### DIFF
--- a/pyorbital/astronomy.py
+++ b/pyorbital/astronomy.py
@@ -155,10 +155,8 @@ def sun_zenith_angle(utc_time, lon, lat):
     lon,lat in degrees.
     The sun zenith angle returned is in degrees.
     """
-    sza = np.rad2deg(np.arccos(cos_zen(utc_time, lon, lat)))
-    if not isinstance(lon, float):
-        sza = sza.astype(lon.dtype)
-    return sza
+    # cos_zen already restores the input dtype, so no separate recast is needed here.
+    return np.rad2deg(np.arccos(cos_zen(utc_time, lon, lat)))
 
 
 def sun_earth_distance_correction(utc_time):

--- a/pyorbital/tests/test_astronomy.py
+++ b/pyorbital/tests/test_astronomy.py
@@ -93,6 +93,36 @@ class TestAstronomy:
             np.testing.assert_allclose(sun_theta, exp_theta, atol=abs_tolerance)
             assert isinstance(sun_theta, type(lon))
 
+    @pytest.mark.parametrize(
+        ("lon", "lat"),
+        [
+            (10, 50),
+            (0, 0),
+            (16, 59),
+            (-75, -30),
+        ]
+    )
+    def test_sun_zenith_angle_integer_scalar(self, lon, lat):
+        """Test that an integer scalar lon/lat neither crashes nor truncates to whole degrees."""
+        # The #156 dtype-preservation recast read ``.dtype`` off the raw ``lon`` argument,
+        # so an ``int`` scalar raised AttributeError instead of returning the angle.
+        time_slot = dt.datetime(2011, 9, 23, 12, 0)
+        expected = astr.sun_zenith_angle(time_slot, float(lon), float(lat))
+        result = astr.sun_zenith_angle(time_slot, lon, lat)
+        assert result == pytest.approx(expected, abs=1e-8)
+        assert isinstance(result, float)
+
+    @pytest.mark.parametrize("dtype", [np.int32, np.int64])
+    def test_sun_zenith_angle_integer_array(self, dtype):
+        """Test that integer-dtype arrays match the float result instead of truncating to whole degrees."""
+        time_slot = dt.datetime(2011, 9, 23, 12, 0)
+        lon = np.array([10, 20, 30, -75], dtype=dtype)
+        lat = np.array([50, 55, 60, -30], dtype=dtype)
+        result = astr.sun_zenith_angle(time_slot, lon, lat)
+        expected = astr.sun_zenith_angle(time_slot, lon.astype(np.float64), lat.astype(np.float64))
+        assert np.issubdtype(result.dtype, np.floating)
+        np.testing.assert_allclose(result, expected, atol=1e-8)
+
     def test_sun_earth_distance_correction(self):
         """Test the sun-earth distance correction."""
         utc_time = dt.datetime(2022, 6, 15, 12, 0, 0)


### PR DESCRIPTION
`sun_zenith_angle` reads `.dtype` off the raw `lon`/`lat` argument, so an integer scalar raises `AttributeError` and an integer array is silently truncated to whole degrees (~1° error). The sibling functions (`get_alt_az`, `cos_zen`, `observer_position`) avoid this because `np.deg2rad` promotes int→float before `.dtype` is read.

```python
>>> import datetime as dt, numpy as np
>>> from pyorbital import astronomy
>>> t = dt.datetime(2020, 6, 21, 12)
>>> astronomy.sun_zenith_angle(t, 10, 50)
AttributeError: 'int' object has no attribute 'dtype'
>>> astronomy.sun_zenith_angle(t, np.array([10, 20, 30]), np.array([50, 55, 60]))
array([27, 34, 41])          # truncated; float input gives [27.586, 34.733, 41.957]
```

The recast is redundant — `cos_zen` already restores the input precision — so removing it fixes both cases while preserving float32/float64 dtypes. This is a residual of the dtype-preservation idiom from #156: that site delegates the angle math to `cos_zen` instead of calling `np.deg2rad` itself, so it read the un-promoted argument. Adds the missing integer-input test coverage; `test_astronomy.py` stays green (21 → 27 passed).
