### PR TITLE
Propagate deep-space satellites (SDP4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.benchmarks
 
 # Translations
 *.mo

--- a/pyorbital/_sgdp4_deep.py
+++ b/pyorbital/_sgdp4_deep.py
@@ -47,12 +47,64 @@ class DeepSpace:
     """
 
     def __init__(self, days_since_1949, eccentricity, arg_perigee, inclination,
-                 right_ascension, mean_motion):
+                 right_ascension, mean_motion, mean_anomaly, sidereal_time_at_epoch,
+                 mean_anomaly_rate, arg_perigee_rate, right_ascension_rate,
+                 semi_major_axis):
         """Work out the geometry and the coefficients that follow from it."""
         self._geometry = compute_lunisolar_geometry(
             days_since_1949, eccentricity, arg_perigee, inclination, right_ascension,
             mean_motion)
         self._secular_rates = compute_secular_rates(self._geometry)
+        self._mean_motion_at_epoch = mean_motion
+        self._arg_perigee_at_epoch = arg_perigee
+        self._arg_perigee_rate = arg_perigee_rate
+        self.resonance = classify_resonance(mean_motion, eccentricity)
+        if self.resonance != NOT_RESONANT:
+            self._prepare_resonance(eccentricity, arg_perigee, right_ascension,
+                                    mean_anomaly, sidereal_time_at_epoch, mean_motion,
+                                    mean_anomaly_rate, arg_perigee_rate,
+                                    right_ascension_rate, semi_major_axis)
+
+    def _prepare_resonance(self, eccentricity, arg_perigee, right_ascension, mean_anomaly,
+                           sidereal_time_at_epoch, mean_motion, mean_anomaly_rate,
+                           arg_perigee_rate, right_ascension_rate, semi_major_axis):
+        """Work out how strongly the orbit beats against the Earth, and from where."""
+        rates = self._secular_rates
+        aonv = 1.0 / semi_major_axis
+        theta = sidereal_time_at_epoch
+
+        if self.resonance != RESONANT_TWICE_A_DAY:
+            raise NotImplementedError(
+                "A satellite that circles once a day is not supported yet")
+
+        self._amplitudes = _twice_daily_resonance(self._geometry, eccentricity,
+                                                  mean_motion, aonv)
+        self._longitude_at_epoch = np.fmod(
+            mean_anomaly + right_ascension + right_ascension - theta - theta, TWO_PI)
+        self._longitude_rate_offset = (
+            mean_anomaly_rate + rates["dmdt"]
+            + 2.0 * (right_ascension_rate + rates["dnodt"] - EARTH_ROTATION)
+            - mean_motion)
+
+    def resonant_correction(self, minutes_since_epoch, right_ascension, arg_perigee,
+                            sidereal_time_at_epoch):
+        """Integrate the beat against the Earth up to this time.
+
+        Returns the mean motion there and the mean anomaly it implies. The
+        integration always restarts from the epoch, so that asking for one time
+        never depends on which times were asked for before.
+        """
+        longitude, mean_motion = _integrate_resonance(
+            minutes_since_epoch, self._longitude_at_epoch, self._mean_motion_at_epoch,
+            self._longitude_rate_offset, self._arg_perigee_at_epoch,
+            self._arg_perigee_rate, self.resonance, self._amplitudes)
+
+        # The bulges of the equator the orbit beats against turn with the Earth.
+        sidereal_time = np.fmod(
+            sidereal_time_at_epoch + minutes_since_epoch * EARTH_ROTATION, TWO_PI)
+
+        mean_anomaly = longitude - 2.0 * right_ascension + 2.0 * sidereal_time
+        return mean_motion, mean_anomaly
 
     def secular_drift(self, minutes_since_epoch):
         """Give the slow change of each element since the epoch."""
@@ -66,6 +118,190 @@ class DeepSpace:
     def periodic_shift(self, minutes_since_epoch):
         """Give the periodic displacement of each element at this time."""
         return compute_periodics(self._geometry, minutes_since_epoch)
+
+
+# Rate at which the Earth turns under the orbit, radians per minute.
+EARTH_ROTATION = 4.37526908801129966e-3
+
+# Amplitudes of the tesseral harmonics that a resonant orbit beats against, and
+# the longitudes of the corresponding bulges.
+ROOT22, ROOT32, ROOT44, ROOT52, ROOT54 = (1.7891679e-6, 3.7393792e-7, 7.3636953e-9,
+                                          1.1428639e-7, 2.1765803e-9)
+G22, G32, G44, G52, G54 = 5.7686396, 0.95240898, 1.8014998, 1.0508330, 4.4108898
+
+# The step the resonance is integrated with, in minutes.
+RESONANCE_STEP = 720.0
+
+NOT_RESONANT = 0
+RESONANT_ONCE_A_DAY = 1
+RESONANT_TWICE_A_DAY = 2
+
+
+def classify_resonance(mean_motion, eccentricity):
+    """Say whether the orbit beats against the Earth's rotation, and how.
+
+    An orbit that circles once or twice while the Earth turns once keeps meeting
+    the same bulges of the equator, so their small pull accumulates instead of
+    averaging away.
+    """
+    if 0.0034906585 < mean_motion < 0.0052359877:
+        return RESONANT_ONCE_A_DAY
+    if 8.26e-3 <= mean_motion <= 9.24e-3 and eccentricity >= 0.5:
+        return RESONANT_TWICE_A_DAY
+    return NOT_RESONANT
+
+
+def _twice_daily_eccentricity_terms(eccentricity):
+    """Fit the tesseral amplitudes to the eccentricity, for a twelve hour orbit."""
+    e = eccentricity
+    esq = e * e
+    ecube = e * esq
+
+    g201 = -0.306 - (e - 0.64) * 0.440
+    if e <= 0.65:
+        g211 = 3.616 - 13.2470 * e + 16.2900 * esq
+        g310 = -19.302 + 117.3900 * e - 228.4190 * esq + 156.5910 * ecube
+        g322 = -18.9068 + 109.7927 * e - 214.6334 * esq + 146.5816 * ecube
+        g410 = -41.122 + 242.6940 * e - 471.0940 * esq + 313.9530 * ecube
+        g422 = -146.407 + 841.8800 * e - 1629.014 * esq + 1083.4350 * ecube
+        g520 = -532.114 + 3017.977 * e - 5740.032 * esq + 3708.2760 * ecube
+    else:
+        g211 = -72.099 + 331.819 * e - 508.738 * esq + 266.724 * ecube
+        g310 = -346.844 + 1582.851 * e - 2415.925 * esq + 1246.113 * ecube
+        g322 = -342.585 + 1554.908 * e - 2366.899 * esq + 1215.972 * ecube
+        g410 = -1052.797 + 4758.686 * e - 7193.992 * esq + 3651.957 * ecube
+        g422 = -3581.690 + 16178.110 * e - 24462.770 * esq + 12422.520 * ecube
+        if e > 0.715:
+            g520 = -5149.66 + 29936.92 * e - 54087.36 * esq + 31324.56 * ecube
+        else:
+            g520 = 1464.74 - 4664.75 * e + 3763.64 * esq
+
+    if e < 0.7:
+        g533 = -919.22770 + 4988.6100 * e - 9064.7700 * esq + 5542.21 * ecube
+        g521 = -822.71072 + 4568.6173 * e - 8491.4146 * esq + 5337.524 * ecube
+        g532 = -853.66600 + 4690.2500 * e - 8624.7700 * esq + 5341.4 * ecube
+    else:
+        g533 = -37995.780 + 161616.52 * e - 229838.20 * esq + 109377.94 * ecube
+        g521 = -51752.104 + 218913.95 * e - 309468.16 * esq + 146349.42 * ecube
+        g532 = -40023.880 + 170470.89 * e - 242699.48 * esq + 115605.82 * ecube
+
+    return g201, g211, g310, g322, g410, g422, g520, g521, g532, g533
+
+
+def _twice_daily_inclination_terms(sinim, cosim):
+    """Fit the tesseral amplitudes to the inclination, for a twelve hour orbit."""
+    cosisq = cosim * cosim
+    sini2 = sinim * sinim
+
+    f220 = 0.75 * (1.0 + 2.0 * cosim + cosisq)
+    f221 = 1.5 * sini2
+    f321 = 1.875 * sinim * (1.0 - 2.0 * cosim - 3.0 * cosisq)
+    f322 = -1.875 * sinim * (1.0 + 2.0 * cosim - 3.0 * cosisq)
+    f441 = 35.0 * sini2 * f220
+    f442 = 39.3750 * sini2 * sini2
+    f522 = 9.84375 * sinim * (sini2 * (1.0 - 2.0 * cosim - 5.0 * cosisq)
+                              + 0.33333333 * (-2.0 + 4.0 * cosim + 6.0 * cosisq))
+    f523 = sinim * (4.92187512 * sini2 * (-2.0 - 4.0 * cosim + 10.0 * cosisq)
+                    + 6.56250012 * (1.0 + 2.0 * cosim - 3.0 * cosisq))
+    f542 = 29.53125 * sinim * (2.0 - 8.0 * cosim
+                               + cosisq * (-12.0 + 8.0 * cosim + 10.0 * cosisq))
+    f543 = 29.53125 * sinim * (-2.0 - 8.0 * cosim
+                               + cosisq * (12.0 + 8.0 * cosim - 10.0 * cosisq))
+    return f220, f221, f321, f322, f441, f442, f522, f523, f542, f543
+
+
+def _twice_daily_resonance(geometry, eccentricity_at_epoch, mean_motion, aonv):
+    """Give the amplitudes with which a twelve hour orbit beats against the Earth."""
+    g201, g211, g310, g322, g410, g422, g520, g521, g532, g533 = (
+        _twice_daily_eccentricity_terms(eccentricity_at_epoch))
+    f220, f221, f321, f322, f441, f442, f522, f523, f542, f543 = (
+        _twice_daily_inclination_terms(geometry["sin_inclination"],
+                                       geometry["cos_inclination"]))
+
+    temp1 = 3.0 * mean_motion * mean_motion * aonv * aonv
+    temp = temp1 * ROOT22
+    amplitudes = {"d2201": temp * f220 * g201, "d2211": temp * f221 * g211}
+    temp1 = temp1 * aonv
+    temp = temp1 * ROOT32
+    amplitudes.update(d3210=temp * f321 * g310, d3222=temp * f322 * g322)
+    temp1 = temp1 * aonv
+    temp = 2.0 * temp1 * ROOT44
+    amplitudes.update(d4410=temp * f441 * g410, d4422=temp * f442 * g422)
+    temp1 = temp1 * aonv
+    temp = temp1 * ROOT52
+    amplitudes.update(d5220=temp * f522 * g520, d5232=temp * f523 * g532)
+    temp = 2.0 * temp1 * ROOT54
+    amplitudes.update(d5421=temp * f542 * g521, d5433=temp * f543 * g533)
+    return amplitudes
+
+
+def _twice_daily_rates(amplitudes, longitude, arg_perigee, mean_longitude_rate):
+    """Give how fast a twelve hour orbit's mean longitude and mean motion change."""
+    a = amplitudes
+    perigee2 = arg_perigee + arg_perigee
+    longitude2 = longitude + longitude
+
+    rate = (a["d2201"] * np.sin(perigee2 + longitude - G22)
+            + a["d2211"] * np.sin(longitude - G22)
+            + a["d3210"] * np.sin(arg_perigee + longitude - G32)
+            + a["d3222"] * np.sin(-arg_perigee + longitude - G32)
+            + a["d4410"] * np.sin(perigee2 + longitude2 - G44)
+            + a["d4422"] * np.sin(longitude2 - G44)
+            + a["d5220"] * np.sin(arg_perigee + longitude - G52)
+            + a["d5232"] * np.sin(-arg_perigee + longitude - G52)
+            + a["d5421"] * np.sin(arg_perigee + longitude2 - G54)
+            + a["d5433"] * np.sin(-arg_perigee + longitude2 - G54))
+    acceleration = (a["d2201"] * np.cos(perigee2 + longitude - G22)
+                    + a["d2211"] * np.cos(longitude - G22)
+                    + a["d3210"] * np.cos(arg_perigee + longitude - G32)
+                    + a["d3222"] * np.cos(-arg_perigee + longitude - G32)
+                    + a["d5220"] * np.cos(arg_perigee + longitude - G52)
+                    + a["d5232"] * np.cos(-arg_perigee + longitude - G52)
+                    + 2.0 * (a["d4410"] * np.cos(perigee2 + longitude2 - G44)
+                             + a["d4422"] * np.cos(longitude2 - G44)
+                             + a["d5421"] * np.cos(arg_perigee + longitude2 - G54)
+                             + a["d5433"] * np.cos(-arg_perigee + longitude2 - G54)))
+    return rate, acceleration * mean_longitude_rate
+
+
+def _integrate_resonance(minutes_since_epoch, longitude_at_epoch, mean_motion_at_epoch,
+                         longitude_rate_offset, arg_perigee_at_epoch, arg_perigee_rate,
+                         resonance, amplitudes):
+    """March the resonance from the epoch to the wanted time in fixed steps.
+
+    The pull depends on where the orbit has drifted to, so it has to be followed
+    step by step rather than evaluated in one go.
+    """
+    step = RESONANCE_STEP if minutes_since_epoch > 0.0 else -RESONANCE_STEP
+    half_step_squared = 0.5 * RESONANCE_STEP * RESONANCE_STEP
+
+    longitude = longitude_at_epoch
+    mean_motion = mean_motion_at_epoch
+    elapsed = 0.0
+
+    while True:
+        rate, acceleration = _resonance_rates(resonance, amplitudes, longitude,
+                                              arg_perigee_at_epoch, arg_perigee_rate,
+                                              elapsed, mean_motion,
+                                              longitude_rate_offset)
+        longitude_rate = mean_motion + longitude_rate_offset
+        if np.abs(minutes_since_epoch - elapsed) < RESONANCE_STEP:
+            break
+        longitude += longitude_rate * step + rate * half_step_squared
+        mean_motion += rate * step + acceleration * half_step_squared
+        elapsed += step
+
+    remaining = minutes_since_epoch - elapsed
+    return (longitude + longitude_rate * remaining + rate * remaining * remaining * 0.5,
+            mean_motion + rate * remaining + acceleration * remaining * remaining * 0.5)
+
+
+def _resonance_rates(resonance, amplitudes, longitude, arg_perigee_at_epoch,
+                     arg_perigee_rate, elapsed, mean_motion, longitude_rate_offset):
+    """Give the rate and the acceleration of the beat at one point of the march."""
+    longitude_rate = mean_motion + longitude_rate_offset
+    arg_perigee = arg_perigee_at_epoch + arg_perigee_rate * elapsed
+    return _twice_daily_rates(amplitudes, longitude, arg_perigee, longitude_rate)
 
 
 def _lunar_geometry(day):

--- a/pyorbital/_sgdp4_deep.py
+++ b/pyorbital/_sgdp4_deep.py
@@ -1,0 +1,385 @@
+"""Deep-space corrections to the SGP4 propagator, following AIAA 2006-6753.
+
+A satellite whose orbit takes 225 minutes or more is far enough from the Earth
+that the Sun and the Moon move it as much as the Earth's own oblateness does,
+and that its orbit can beat against the Earth's rotation. SGP4 leaves both out;
+this module adds them, in the three steps the article describes:
+
+* the geometry of the Sun and the Moon relative to the orbit at the epoch, and
+  the coefficients derived from it, computed once (``dscom``, ``dsinit``);
+* the slow drift those two bodies impose, added to the secular rates before
+  each propagation, together with the beat against the Earth's rotation for the
+  orbits that resonate with it (``dspace``);
+* the periodic wobble they impose, added to the orbital elements themselves
+  (``dpper``).
+
+The names of the coefficients are the ones used in the article, so that the two
+can be read side by side.
+"""
+
+import numpy as np
+
+TWO_PI = 2.0 * np.pi
+
+# Amplitude of the solar and lunar perturbations, and the eccentricity of the
+# Earth's orbit about the Sun and of the Moon's about the Earth.
+SOLAR_PERTURBATION = 2.9864797e-6
+LUNAR_PERTURBATION = 4.7968065e-7
+SOLAR_ECCENTRICITY = 0.01675
+LUNAR_ECCENTRICITY = 0.05490
+
+# The Sun's position in the orbital plane of the Earth, at the reference epoch.
+SOLAR_SIN_INCLINATION = 0.39785416
+SOLAR_COS_INCLINATION = 0.91744867
+SOLAR_COS_ARG_PERIGEE = 0.1945905
+SOLAR_SIN_ARG_PERIGEE = -0.98088458
+
+# Days between 1949 December 31 and 1900 January 0, the epoch the lunar
+# ephemeris below is written against.
+DAYS_FROM_1900 = 18261.5
+
+
+class DeepSpace:
+    """The Sun and the Moon, as they act on one satellite's orbit.
+
+    Built once from the orbit at its epoch, then asked at each propagation for
+    the drift and the wobble to add to the mean elements.
+    """
+
+    def __init__(self, days_since_1949, eccentricity, arg_perigee, inclination,
+                 right_ascension, mean_motion):
+        """Work out the geometry and the coefficients that follow from it."""
+        self._geometry = compute_lunisolar_geometry(
+            days_since_1949, eccentricity, arg_perigee, inclination, right_ascension,
+            mean_motion)
+        self._secular_rates = compute_secular_rates(self._geometry)
+
+    def secular_drift(self, minutes_since_epoch):
+        """Give the slow change of each element since the epoch."""
+        rates = self._secular_rates
+        return dict(eccentricity=rates["dedt"] * minutes_since_epoch,
+                    inclination=rates["didt"] * minutes_since_epoch,
+                    mean_anomaly=rates["dmdt"] * minutes_since_epoch,
+                    arg_perigee=rates["domdt"] * minutes_since_epoch,
+                    right_ascension=rates["dnodt"] * minutes_since_epoch)
+
+    def periodic_shift(self, minutes_since_epoch):
+        """Give the periodic displacement of each element at this time."""
+        return compute_periodics(self._geometry, minutes_since_epoch)
+
+
+def _lunar_geometry(day):
+    """Locate the Moon's orbital plane and perigee on the given day.
+
+    The Moon's node regresses once around in about 18.6 years and its orbit is
+    inclined to the ecliptic, so unlike the Sun's its geometry cannot be taken
+    as fixed.
+    """
+    node = np.fmod(4.5236020 - 9.2422029e-4 * day, TWO_PI)
+    sin_node, cos_node = np.sin(node), np.cos(node)
+
+    cos_inclination = 0.91375164 - 0.03568096 * cos_node
+    sin_inclination = np.sqrt(1.0 - cos_inclination * cos_inclination)
+    sin_node_ecliptic = 0.089683511 * sin_node / sin_inclination
+    cos_node_ecliptic = np.sqrt(1.0 - sin_node_ecliptic * sin_node_ecliptic)
+
+    mean_longitude = 5.8351514 + 0.0019443680 * day
+    argument = np.arctan2(
+        SOLAR_SIN_INCLINATION * sin_node / sin_inclination,
+        cos_node_ecliptic * cos_node + SOLAR_COS_INCLINATION * sin_node_ecliptic * sin_node,
+    )
+    argument = mean_longitude + argument - node
+
+    return dict(sin_inclination=sin_inclination, cos_inclination=cos_inclination,
+                sin_node=sin_node_ecliptic, cos_node=cos_node_ecliptic,
+                sin_arg_perigee=np.sin(argument), cos_arg_perigee=np.cos(argument),
+                mean_longitude=mean_longitude)
+
+
+def _third_body_terms(perturbing, orbit):
+    """Project one perturbing body onto the satellite's orbit.
+
+    Returns the ``s`` and ``z`` coefficients of the article, which describe how
+    that body's pull varies around the orbit. The same projection serves the
+    Sun and the Moon; only the direction of the perturbing body differs.
+    """
+    zcosg, zsing = perturbing["cos_arg_perigee"], perturbing["sin_arg_perigee"]
+    zcosi, zsini = perturbing["cos_inclination"], perturbing["sin_inclination"]
+    zcosh, zsinh = perturbing["cos_node"], perturbing["sin_node"]
+
+    cosim, sinim = orbit["cos_inclination"], orbit["sin_inclination"]
+    cosomm, sinomm = orbit["cos_arg_perigee"], orbit["sin_arg_perigee"]
+    emsq, betasq, rtemsq = orbit["emsq"], orbit["betasq"], orbit["rtemsq"]
+
+    a1 = zcosg * zcosh + zsing * zcosi * zsinh
+    a3 = -zsing * zcosh + zcosg * zcosi * zsinh
+    a7 = -zcosg * zsinh + zsing * zcosi * zcosh
+    a8 = zsing * zsini
+    a9 = zsing * zsinh + zcosg * zcosi * zcosh
+    a10 = zcosg * zsini
+    a2 = cosim * a7 + sinim * a8
+    a4 = cosim * a9 + sinim * a10
+    a5 = -sinim * a7 + cosim * a8
+    a6 = -sinim * a9 + cosim * a10
+
+    x1 = a1 * cosomm + a2 * sinomm
+    x2 = a3 * cosomm + a4 * sinomm
+    x3 = -a1 * sinomm + a2 * cosomm
+    x4 = -a3 * sinomm + a4 * cosomm
+    x5 = a5 * sinomm
+    x6 = a6 * sinomm
+    x7 = a5 * cosomm
+    x8 = a6 * cosomm
+
+    z31 = 12.0 * x1 * x1 - 3.0 * x3 * x3
+    z32 = 24.0 * x1 * x2 - 6.0 * x3 * x4
+    z33 = 12.0 * x2 * x2 - 3.0 * x4 * x4
+
+    z1 = 3.0 * (a1 * a1 + a2 * a2) + z31 * emsq
+    z2 = 6.0 * (a1 * a3 + a2 * a4) + z32 * emsq
+    z3 = 3.0 * (a3 * a3 + a4 * a4) + z33 * emsq
+    z11 = -6.0 * a1 * a5 + emsq * (-24.0 * x1 * x7 - 6.0 * x3 * x5)
+    z12 = (-6.0 * (a1 * a6 + a3 * a5)
+           + emsq * (-24.0 * (x2 * x7 + x1 * x8) - 6.0 * (x3 * x6 + x4 * x5)))
+    z13 = -6.0 * a3 * a6 + emsq * (-24.0 * x2 * x8 - 6.0 * x4 * x6)
+    z21 = 6.0 * a2 * a5 + emsq * (24.0 * x1 * x5 - 6.0 * x3 * x7)
+    z22 = (6.0 * (a4 * a5 + a2 * a6)
+           + emsq * (24.0 * (x2 * x5 + x1 * x6) - 6.0 * (x4 * x7 + x3 * x8)))
+    z23 = 6.0 * a4 * a6 + emsq * (24.0 * x2 * x6 - 6.0 * x4 * x8)
+    z1 = z1 + z1 + betasq * z31
+    z2 = z2 + z2 + betasq * z32
+    z3 = z3 + z3 + betasq * z33
+
+    s3 = perturbing["amplitude"] / orbit["mean_motion"]
+    s2 = -0.5 * s3 / rtemsq
+    s4 = s3 * rtemsq
+    s1 = -15.0 * orbit["eccentricity"] * s4
+    s5 = x1 * x3 + x2 * x4
+    s6 = x2 * x3 + x1 * x4
+    s7 = x2 * x4 - x1 * x3
+
+    return dict(s1=s1, s2=s2, s3=s3, s4=s4, s5=s5, s6=s6, s7=s7,
+                z1=z1, z2=z2, z3=z3, z11=z11, z12=z12, z13=z13,
+                z21=z21, z22=z22, z23=z23, z31=z31, z32=z32, z33=z33)
+
+
+def _solar_geometry(sin_node, cos_node):
+    """Locate the Sun's orbital plane and perigee, which barely move."""
+    return dict(sin_inclination=SOLAR_SIN_INCLINATION, cos_inclination=SOLAR_COS_INCLINATION,
+                sin_arg_perigee=SOLAR_SIN_ARG_PERIGEE, cos_arg_perigee=SOLAR_COS_ARG_PERIGEE,
+                sin_node=sin_node, cos_node=cos_node, amplitude=SOLAR_PERTURBATION)
+
+
+def _moon_relative_to_orbit(moon, sin_node, cos_node):
+    """Express the Moon's node relative to the satellite's node."""
+    return dict(moon,
+                sin_node=sin_node * moon["cos_node"] - cos_node * moon["sin_node"],
+                cos_node=moon["cos_node"] * cos_node + moon["sin_node"] * sin_node,
+                amplitude=LUNAR_PERTURBATION)
+
+
+def compute_lunisolar_geometry(days_since_1949, eccentricity, arg_perigee,
+                               inclination, right_ascension, mean_motion):
+    """Describe how the Sun and the Moon pull on the orbit (``dscom``)."""
+    day = days_since_1949 + DAYS_FROM_1900
+
+    sin_node, cos_node = np.sin(right_ascension), np.cos(right_ascension)
+    emsq = eccentricity * eccentricity
+    betasq = 1.0 - emsq
+    orbit = dict(sin_inclination=np.sin(inclination), cos_inclination=np.cos(inclination),
+                 sin_arg_perigee=np.sin(arg_perigee), cos_arg_perigee=np.cos(arg_perigee),
+                 eccentricity=eccentricity, emsq=emsq, betasq=betasq,
+                 rtemsq=np.sqrt(betasq), mean_motion=mean_motion)
+
+    moon = _lunar_geometry(day)
+    solar = _third_body_terms(_solar_geometry(sin_node, cos_node), orbit)
+    lunar = _third_body_terms(_moon_relative_to_orbit(moon, sin_node, cos_node), orbit)
+
+    geometry = dict(orbit)
+    geometry["day"] = day
+    geometry["solar"] = solar
+    geometry["lunar"] = lunar
+    geometry["zmol"] = np.fmod(4.7199672 + 0.22997150 * day - moon["mean_longitude"], TWO_PI)
+    geometry["zmos"] = np.fmod(6.2565837 + 0.017201977 * day, TWO_PI)
+    geometry.update(_periodic_coefficients(solar, lunar, emsq))
+    return geometry
+
+
+# Mean motion of the Sun and of the Moon about the Earth, radians per minute.
+SOLAR_MEAN_MOTION = 1.19459e-5
+LUNAR_MEAN_MOTION = 1.5835218e-4
+
+# Within three degrees of the equator, prograde or retrograde, the node is too
+# poorly defined to perturb.
+POLAR_INCLINATION_LIMIT = 5.2359877e-2
+
+# Below this inclination the node and the argument of perigee are replaced by
+# the Lyddane variables, which stay well behaved as the orbit flattens out.
+LYDDANE_INCLINATION_LIMIT = 0.2
+
+
+def compute_secular_rates(geometry):
+    """Give the drift the Sun and the Moon impose on the orbit (part of ``dsinit``).
+
+    Returned as rates per minute for eccentricity, inclination, mean anomaly,
+    argument of perigee and right ascension.
+    """
+    solar, lunar = geometry["solar"], geometry["lunar"]
+    emsq = geometry["emsq"]
+    sinim, cosim = geometry["sin_inclination"], geometry["cos_inclination"]
+
+    ses = solar["s1"] * SOLAR_MEAN_MOTION * solar["s5"]
+    sis = solar["s2"] * SOLAR_MEAN_MOTION * (solar["z11"] + solar["z13"])
+    sls = -SOLAR_MEAN_MOTION * solar["s3"] * (solar["z1"] + solar["z3"] - 14.0 - 6.0 * emsq)
+    sghs = solar["s4"] * SOLAR_MEAN_MOTION * (solar["z31"] + solar["z33"] - 6.0)
+    shs = -SOLAR_MEAN_MOTION * solar["s2"] * (solar["z21"] + solar["z23"])
+
+    inclination = np.arctan2(sinim, cosim)
+    if _node_is_ill_defined(inclination):
+        shs = 0.0
+    if sinim != 0.0:
+        shs = shs / sinim
+    sgs = sghs - cosim * shs
+
+    dedt = ses + lunar["s1"] * LUNAR_MEAN_MOTION * lunar["s5"]
+    didt = sis + lunar["s2"] * LUNAR_MEAN_MOTION * (lunar["z11"] + lunar["z13"])
+    dmdt = sls - LUNAR_MEAN_MOTION * lunar["s3"] * (lunar["z1"] + lunar["z3"] - 14.0 - 6.0 * emsq)
+    sghl = lunar["s4"] * LUNAR_MEAN_MOTION * (lunar["z31"] + lunar["z33"] - 6.0)
+    shll = -LUNAR_MEAN_MOTION * lunar["s2"] * (lunar["z21"] + lunar["z23"])
+    if _node_is_ill_defined(inclination):
+        shll = 0.0
+
+    domdt = sgs + sghl
+    dnodt = shs
+    if sinim != 0.0:
+        domdt = domdt - cosim / sinim * shll
+        dnodt = dnodt + shll / sinim
+
+    return dict(dedt=dedt, didt=didt, dmdt=dmdt, domdt=domdt, dnodt=dnodt)
+
+
+def _node_is_ill_defined(inclination):
+    """Tell whether the orbit lies too close to the equatorial plane."""
+    return (inclination < POLAR_INCLINATION_LIMIT
+            or inclination > np.pi - POLAR_INCLINATION_LIMIT)
+
+
+def _wobble(coefficients, phase, eccentricity_of_orbit):
+    """Evaluate one body's periodic contribution at the given phase."""
+    angle = phase + 2.0 * eccentricity_of_orbit * np.sin(phase)
+    sin_angle = np.sin(angle)
+    f2 = 0.5 * sin_angle * sin_angle - 0.25
+    f3 = -0.5 * sin_angle * np.cos(angle)
+    two, three, four = coefficients
+    return two * f2 + three * f3 + (0.0 if four is None else four * sin_angle)
+
+
+def compute_periodics(geometry, minutes_since_epoch):
+    """Give the periodic shift the Sun and the Moon impose (first half of ``dpper``)."""
+    g = geometry
+    solar_phase = g["zmos"] + SOLAR_MEAN_MOTION * minutes_since_epoch
+    lunar_phase = g["zmol"] + LUNAR_MEAN_MOTION * minutes_since_epoch
+
+    def solar(two, three, four=None):
+        return _wobble((g[two], g[three], None if four is None else g[four]),
+                       solar_phase, SOLAR_ECCENTRICITY)
+
+    def lunar(two, three, four=None):
+        return _wobble((g[two], g[three], None if four is None else g[four]),
+                       lunar_phase, LUNAR_ECCENTRICITY)
+
+    return dict(
+        eccentricity=solar("se2", "se3") + lunar("ee2", "e3"),
+        inclination=solar("si2", "si3") + lunar("xi2", "xi3"),
+        mean_anomaly=solar("sl2", "sl3", "sl4") + lunar("xl2", "xl3", "xl4"),
+        arg_perigee=solar("sgh2", "sgh3", "sgh4") + lunar("xgh2", "xgh3", "xgh4"),
+        right_ascension=solar("sh2", "sh3") + lunar("xh2", "xh3"),
+    )
+
+
+def apply_periodics(shift, eccentricity, inclination, right_ascension, arg_perigee,
+                    mean_anomaly):
+    """Add the periodic shift to the orbital elements (second half of ``dpper``)."""
+    inclination = inclination + shift["inclination"]
+    eccentricity = eccentricity + shift["eccentricity"]
+    sin_inc, cos_inc = np.sin(inclination), np.cos(inclination)
+
+    if inclination >= LYDDANE_INCLINATION_LIMIT:
+        node_shift = shift["right_ascension"] / sin_inc
+        arg_perigee = arg_perigee + shift["arg_perigee"] - cos_inc * node_shift
+        right_ascension = right_ascension + node_shift
+        mean_anomaly = mean_anomaly + shift["mean_anomaly"]
+        return eccentricity, inclination, right_ascension, arg_perigee, mean_anomaly
+
+    return (eccentricity, inclination,
+            *_apply_periodics_near_equator(shift, sin_inc, cos_inc, right_ascension,
+                                           arg_perigee, mean_anomaly))
+
+
+def _turn_to_positive(angle):
+    """Bring an angle into a whole turn measured from zero.
+
+    Here the right ascension is used as a number rather than as the argument of
+    a sine or a cosine, so whether it is measured from zero or from minus half a
+    turn changes the result. The operational software measures it from zero, and
+    the element sets this model is fed come from that software.
+    """
+    return angle + TWO_PI if angle < 0.0 else angle
+
+
+def _apply_periodics_near_equator(shift, sin_inc, cos_inc, right_ascension, arg_perigee,
+                                  mean_anomaly):
+    """Add the shift through the Lyddane variables, for a nearly equatorial orbit.
+
+    Close to the equator the node swings wildly for a small change of the
+    orbital plane, so the plane itself is shifted instead and the node read back
+    from it.
+    """
+    sin_node, cos_node = np.sin(right_ascension), np.cos(right_ascension)
+    plane_x = sin_inc * sin_node + (shift["right_ascension"] * cos_node
+                                    + shift["inclination"] * cos_inc * sin_node)
+    plane_y = sin_inc * cos_node + (-shift["right_ascension"] * sin_node
+                                    + shift["inclination"] * cos_inc * cos_node)
+
+    right_ascension = _turn_to_positive(np.fmod(right_ascension, TWO_PI))
+    mean_longitude = (mean_anomaly + arg_perigee + shift["mean_anomaly"] + shift["arg_perigee"]
+                      + (cos_inc - shift["inclination"] * sin_inc) * right_ascension)
+
+    previous_node = right_ascension
+    right_ascension = _turn_to_positive(np.arctan2(plane_x, plane_y))
+    if np.abs(previous_node - right_ascension) > np.pi:
+        right_ascension += TWO_PI if right_ascension < previous_node else -TWO_PI
+
+    mean_anomaly = mean_anomaly + shift["mean_anomaly"]
+    arg_perigee = mean_longitude - mean_anomaly - cos_inc * right_ascension
+    return right_ascension, arg_perigee, mean_anomaly
+
+
+def _periodic_coefficients(solar, lunar, emsq):
+    """Combine the projections into the coefficients ``dpper`` applies."""
+    return dict(
+        se2=2.0 * solar["s1"] * solar["s6"],
+        se3=2.0 * solar["s1"] * solar["s7"],
+        si2=2.0 * solar["s2"] * solar["z12"],
+        si3=2.0 * solar["s2"] * (solar["z13"] - solar["z11"]),
+        sl2=-2.0 * solar["s3"] * solar["z2"],
+        sl3=-2.0 * solar["s3"] * (solar["z3"] - solar["z1"]),
+        sl4=-2.0 * solar["s3"] * (-21.0 - 9.0 * emsq) * SOLAR_ECCENTRICITY,
+        sgh2=2.0 * solar["s4"] * solar["z32"],
+        sgh3=2.0 * solar["s4"] * (solar["z33"] - solar["z31"]),
+        sgh4=-18.0 * solar["s4"] * SOLAR_ECCENTRICITY,
+        sh2=-2.0 * solar["s2"] * solar["z22"],
+        sh3=-2.0 * solar["s2"] * (solar["z23"] - solar["z21"]),
+        ee2=2.0 * lunar["s1"] * lunar["s6"],
+        e3=2.0 * lunar["s1"] * lunar["s7"],
+        xi2=2.0 * lunar["s2"] * lunar["z12"],
+        xi3=2.0 * lunar["s2"] * (lunar["z13"] - lunar["z11"]),
+        xl2=-2.0 * lunar["s3"] * lunar["z2"],
+        xl3=-2.0 * lunar["s3"] * (lunar["z3"] - lunar["z1"]),
+        xl4=-2.0 * lunar["s3"] * (-21.0 - 9.0 * emsq) * LUNAR_ECCENTRICITY,
+        xgh2=2.0 * lunar["s4"] * lunar["z32"],
+        xgh3=2.0 * lunar["s4"] * (lunar["z33"] - lunar["z31"]),
+        xgh4=-18.0 * lunar["s4"] * LUNAR_ECCENTRICITY,
+        xh2=-2.0 * lunar["s2"] * lunar["z22"],
+        xh3=-2.0 * lunar["s2"] * (lunar["z23"] - lunar["z21"]),
+    )

--- a/pyorbital/_sgdp4_deep.py
+++ b/pyorbital/_sgdp4_deep.py
@@ -73,18 +73,24 @@ class DeepSpace:
         aonv = 1.0 / semi_major_axis
         theta = sidereal_time_at_epoch
 
-        if self.resonance != RESONANT_TWICE_A_DAY:
-            raise NotImplementedError(
-                "A satellite that circles once a day is not supported yet")
-
-        self._amplitudes = _twice_daily_resonance(self._geometry, eccentricity,
-                                                  mean_motion, aonv)
-        self._longitude_at_epoch = np.fmod(
-            mean_anomaly + right_ascension + right_ascension - theta - theta, TWO_PI)
-        self._longitude_rate_offset = (
-            mean_anomaly_rate + rates["dmdt"]
-            + 2.0 * (right_ascension_rate + rates["dnodt"] - EARTH_ROTATION)
-            - mean_motion)
+        if self.resonance == RESONANT_TWICE_A_DAY:
+            self._amplitudes = _twice_daily_resonance(self._geometry, eccentricity,
+                                                      mean_motion, aonv)
+            self._longitude_at_epoch = np.fmod(
+                mean_anomaly + right_ascension + right_ascension - theta - theta, TWO_PI)
+            self._longitude_rate_offset = (
+                mean_anomaly_rate + rates["dmdt"]
+                + 2.0 * (right_ascension_rate + rates["dnodt"] - EARTH_ROTATION)
+                - mean_motion)
+        else:
+            self._amplitudes = _once_daily_resonance(self._geometry, eccentricity,
+                                                     mean_motion, aonv)
+            self._longitude_at_epoch = np.fmod(
+                mean_anomaly + right_ascension + arg_perigee - theta, TWO_PI)
+            self._longitude_rate_offset = (
+                mean_anomaly_rate + arg_perigee_rate + right_ascension_rate
+                - EARTH_ROTATION + rates["dmdt"] + rates["domdt"] + rates["dnodt"]
+                - mean_motion)
 
     def resonant_correction(self, minutes_since_epoch, right_ascension, arg_perigee,
                             sidereal_time_at_epoch):
@@ -103,7 +109,10 @@ class DeepSpace:
         sidereal_time = np.fmod(
             sidereal_time_at_epoch + minutes_since_epoch * EARTH_ROTATION, TWO_PI)
 
-        mean_anomaly = longitude - 2.0 * right_ascension + 2.0 * sidereal_time
+        if self.resonance == RESONANT_TWICE_A_DAY:
+            mean_anomaly = longitude - 2.0 * right_ascension + 2.0 * sidereal_time
+        else:
+            mean_anomaly = longitude - right_ascension - arg_perigee + sidereal_time
         return mean_motion, mean_anomaly
 
     def secular_drift(self, minutes_since_epoch):
@@ -128,6 +137,10 @@ EARTH_ROTATION = 4.37526908801129966e-3
 ROOT22, ROOT32, ROOT44, ROOT52, ROOT54 = (1.7891679e-6, 3.7393792e-7, 7.3636953e-9,
                                           1.1428639e-7, 2.1765803e-9)
 G22, G32, G44, G52, G54 = 5.7686396, 0.95240898, 1.8014998, 1.0508330, 4.4108898
+
+# The same for the harmonics a geosynchronous orbit meets, once a day.
+Q22, Q31, Q33 = 1.7891679e-6, 2.1460748e-6, 2.2123015e-7
+FASX2, FASX4, FASX6 = 0.13130908, 2.8843198, 0.37448087
 
 # The step the resonance is integrated with, in minutes.
 RESONANCE_STEP = 720.0
@@ -264,6 +277,36 @@ def _twice_daily_rates(amplitudes, longitude, arg_perigee, mean_longitude_rate):
     return rate, acceleration * mean_longitude_rate
 
 
+def _once_daily_resonance(geometry, eccentricity, mean_motion, aonv):
+    """Give the amplitudes with which a geosynchronous orbit beats against the Earth."""
+    sinim, cosim = geometry["sin_inclination"], geometry["cos_inclination"]
+    emsq = eccentricity * eccentricity
+
+    g200 = 1.0 + emsq * (-2.5 + 0.8125 * emsq)
+    g310 = 1.0 + 2.0 * emsq
+    g300 = 1.0 + emsq * (-6.0 + 6.60937 * emsq)
+    f220 = 0.75 * (1.0 + cosim) * (1.0 + cosim)
+    f311 = 0.9375 * sinim * sinim * (1.0 + 3.0 * cosim) - 0.75 * (1.0 + cosim)
+    f330 = 1.0 + cosim
+    f330 = 1.875 * f330 * f330 * f330
+
+    scale = 3.0 * mean_motion * mean_motion * aonv * aonv
+    return {"del2": 2.0 * scale * f220 * g200 * Q22,
+            "del3": 3.0 * scale * f330 * g300 * Q33 * aonv,
+            "del1": scale * f311 * g310 * Q31 * aonv}
+
+
+def _once_daily_rates(amplitudes, longitude, mean_longitude_rate):
+    """Give how fast a geosynchronous orbit's mean longitude and mean motion change."""
+    rate = (amplitudes["del1"] * np.sin(longitude - FASX2)
+            + amplitudes["del2"] * np.sin(2.0 * (longitude - FASX4))
+            + amplitudes["del3"] * np.sin(3.0 * (longitude - FASX6)))
+    acceleration = (amplitudes["del1"] * np.cos(longitude - FASX2)
+                    + 2.0 * amplitudes["del2"] * np.cos(2.0 * (longitude - FASX4))
+                    + 3.0 * amplitudes["del3"] * np.cos(3.0 * (longitude - FASX6)))
+    return rate, acceleration * mean_longitude_rate
+
+
 def _integrate_resonance(minutes_since_epoch, longitude_at_epoch, mean_motion_at_epoch,
                          longitude_rate_offset, arg_perigee_at_epoch, arg_perigee_rate,
                          resonance, amplitudes):
@@ -300,8 +343,10 @@ def _resonance_rates(resonance, amplitudes, longitude, arg_perigee_at_epoch,
                      arg_perigee_rate, elapsed, mean_motion, longitude_rate_offset):
     """Give the rate and the acceleration of the beat at one point of the march."""
     longitude_rate = mean_motion + longitude_rate_offset
-    arg_perigee = arg_perigee_at_epoch + arg_perigee_rate * elapsed
-    return _twice_daily_rates(amplitudes, longitude, arg_perigee, longitude_rate)
+    if resonance == RESONANT_TWICE_A_DAY:
+        arg_perigee = arg_perigee_at_epoch + arg_perigee_rate * elapsed
+        return _twice_daily_rates(amplitudes, longitude, arg_perigee, longitude_rate)
+    return _once_daily_rates(amplitudes, longitude, longitude_rate)
 
 
 def _lunar_geometry(day):

--- a/pyorbital/_sgdp4_deep.py
+++ b/pyorbital/_sgdp4_deep.py
@@ -315,26 +315,39 @@ def _integrate_resonance(minutes_since_epoch, longitude_at_epoch, mean_motion_at
     The pull depends on where the orbit has drifted to, so it has to be followed
     step by step rather than evaluated in one go.
     """
-    step = RESONANCE_STEP if minutes_since_epoch > 0.0 else -RESONANCE_STEP
+    minutes = np.asarray(minutes_since_epoch, dtype=float)
     half_step_squared = 0.5 * RESONANCE_STEP * RESONANCE_STEP
 
-    longitude = longitude_at_epoch
-    mean_motion = mean_motion_at_epoch
-    elapsed = 0.0
+    # Every time marches from the epoch in whole steps until less than one step
+    # is left, so the number of steps it takes follows from the time alone.
+    step = np.where(minutes < 0.0, -RESONANCE_STEP, RESONANCE_STEP)
+    steps_to_take = np.floor(np.abs(minutes) / RESONANCE_STEP)
 
-    while True:
+    longitude = np.broadcast_to(float(longitude_at_epoch), minutes.shape).copy()
+    mean_motion = np.broadcast_to(float(mean_motion_at_epoch), minutes.shape).copy()
+    elapsed = np.zeros(minutes.shape)
+
+    for step_number in range(int(steps_to_take.max())):
         rate, acceleration = _resonance_rates(resonance, amplitudes, longitude,
                                               arg_perigee_at_epoch, arg_perigee_rate,
                                               elapsed, mean_motion,
                                               longitude_rate_offset)
         longitude_rate = mean_motion + longitude_rate_offset
-        if np.abs(minutes_since_epoch - elapsed) < RESONANCE_STEP:
-            break
-        longitude += longitude_rate * step + rate * half_step_squared
-        mean_motion += rate * step + acceleration * half_step_squared
-        elapsed += step
+        still_marching = steps_to_take > step_number
+        longitude = np.where(still_marching,
+                             longitude + longitude_rate * step + rate * half_step_squared,
+                             longitude)
+        mean_motion = np.where(still_marching,
+                               mean_motion + rate * step + acceleration * half_step_squared,
+                               mean_motion)
+        elapsed = np.where(still_marching, elapsed + step, elapsed)
 
-    remaining = minutes_since_epoch - elapsed
+    rate, acceleration = _resonance_rates(resonance, amplitudes, longitude,
+                                          arg_perigee_at_epoch, arg_perigee_rate,
+                                          elapsed, mean_motion, longitude_rate_offset)
+    longitude_rate = mean_motion + longitude_rate_offset
+
+    remaining = minutes - elapsed
     return (longitude + longitude_rate * remaining + rate * remaining * remaining * 0.5,
             mean_motion + rate * remaining + acceleration * remaining * remaining * 0.5)
 
@@ -580,21 +593,40 @@ def compute_periodics(geometry, minutes_since_epoch):
 
 def apply_periodics(shift, eccentricity, inclination, right_ascension, arg_perigee,
                     mean_anomaly):
-    """Add the periodic shift to the orbital elements (second half of ``dpper``)."""
+    """Add the periodic shift to the orbital elements (second half of ``dpper``).
+
+    Both ways of adding it are worked out and then chosen between, so that a
+    whole array of times can be propagated at once even when some of them have
+    the orbit tipped over the inclination that separates the two.
+    """
     inclination = inclination + shift["inclination"]
     eccentricity = eccentricity + shift["eccentricity"]
     sin_inc, cos_inc = np.sin(inclination), np.cos(inclination)
 
-    if inclination >= LYDDANE_INCLINATION_LIMIT:
-        node_shift = shift["right_ascension"] / sin_inc
-        arg_perigee = arg_perigee + shift["arg_perigee"] - cos_inc * node_shift
-        right_ascension = right_ascension + node_shift
-        mean_anomaly = mean_anomaly + shift["mean_anomaly"]
-        return eccentricity, inclination, right_ascension, arg_perigee, mean_anomaly
+    tilted = _apply_periodics_directly(shift, sin_inc, cos_inc, right_ascension,
+                                       arg_perigee, mean_anomaly)
+    flat = _apply_periodics_near_equator(shift, sin_inc, cos_inc, right_ascension,
+                                         arg_perigee, mean_anomaly)
 
-    return (eccentricity, inclination,
-            *_apply_periodics_near_equator(shift, sin_inc, cos_inc, right_ascension,
-                                           arg_perigee, mean_anomaly))
+    is_tilted = inclination >= LYDDANE_INCLINATION_LIMIT
+    right_ascension, arg_perigee, mean_anomaly = (
+        np.where(is_tilted, from_tilted, from_flat)
+        for from_tilted, from_flat in zip(tilted, flat))
+    return eccentricity, inclination, right_ascension, arg_perigee, mean_anomaly
+
+
+def _apply_periodics_directly(shift, sin_inc, cos_inc, right_ascension, arg_perigee,
+                              mean_anomaly):
+    """Add the shift to the elements themselves, for an orbit that is tilted enough."""
+    node_shift = shift["right_ascension"] / _without_zeros(sin_inc)
+    return (right_ascension + node_shift,
+            arg_perigee + shift["arg_perigee"] - cos_inc * node_shift,
+            mean_anomaly + shift["mean_anomaly"])
+
+
+def _without_zeros(divisor):
+    """Replace zeros by ones, for a division whose result is about to be discarded."""
+    return np.where(divisor == 0.0, 1.0, divisor)
 
 
 def _turn_to_positive(angle):
@@ -605,7 +637,7 @@ def _turn_to_positive(angle):
     turn changes the result. The operational software measures it from zero, and
     the element sets this model is fed come from that software.
     """
-    return angle + TWO_PI if angle < 0.0 else angle
+    return np.where(angle < 0.0, angle + TWO_PI, angle)
 
 
 def _apply_periodics_near_equator(shift, sin_inc, cos_inc, right_ascension, arg_perigee,
@@ -628,12 +660,18 @@ def _apply_periodics_near_equator(shift, sin_inc, cos_inc, right_ascension, arg_
 
     previous_node = right_ascension
     right_ascension = _turn_to_positive(np.arctan2(plane_x, plane_y))
-    if np.abs(previous_node - right_ascension) > np.pi:
-        right_ascension += TWO_PI if right_ascension < previous_node else -TWO_PI
+    right_ascension = _keep_on_the_same_turn(right_ascension, previous_node)
 
     mean_anomaly = mean_anomaly + shift["mean_anomaly"]
     arg_perigee = mean_longitude - mean_anomaly - cos_inc * right_ascension
     return right_ascension, arg_perigee, mean_anomaly
+
+
+def _keep_on_the_same_turn(angle, previous):
+    """Undo the jump a whole turn makes when the node crosses the end of its range."""
+    jumped = np.abs(previous - angle) > np.pi
+    return np.where(jumped, np.where(angle < previous, angle + TWO_PI, angle - TWO_PI),
+                    angle)
 
 
 def _periodic_coefficients(solar, lunar, emsq):

--- a/pyorbital/geoloc.py
+++ b/pyorbital/geoloc.py
@@ -201,7 +201,12 @@ def compute_pixels(orb, sgeom, times, rpy=(0.0, 0.0, 0.0)):
     lsq = np.einsum("ij,ij->j", xr_, xr_)
     csq = np.einsum("ij,ij->j", cr_, cr_)
 
-    d1_ = (ldotc - np.sqrt(ldotc ** 2 - csq * lsq + lsq)) / lsq
+    # A ray that misses the ellipsoid has no intersection to find. Clamping
+    # the discriminant to zero returns the point of closest approach on the
+    # tangent line, which keeps results finite and continuous while an
+    # optimizer explores attitudes that point past the edge of the Earth.
+    discriminant = np.maximum(ldotc ** 2 - csq * lsq + lsq, 0.0)
+    d1_ = (ldotc - np.sqrt(discriminant)) / lsq
 
     # return the actual pixel positions
     return vectors * d1_.reshape(shape[1:]) - centre

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import optimize
 
 from pyorbital import astronomy, dt2np
-from pyorbital._sgdp4_deep import DeepSpace, apply_periodics
+from pyorbital._sgdp4_deep import NOT_RESONANT, DeepSpace, apply_periodics
 
 try:
     import dask.array as da
@@ -765,8 +765,11 @@ class _SGDP4Base:
 
         self.deep_space = None
         if self.mode == SGDP4_DEEP_NORM:
-            self.deep_space = DeepSpace(self._days_since_1949(), self.eo, self.omegao,
-                                        self.xincl, self.xnodeo, self.xnodp)
+            self.sidereal_time_at_epoch = np.fmod(astronomy.gmst(self.t_0), 2 * np.pi)
+            self.deep_space = DeepSpace(
+                self._days_since_1949(), self.eo, self.omegao, self.xincl, self.xnodeo,
+                self.xnodp, self.xmo, self.sidereal_time_at_epoch, self.xmdot,
+                self.omgdot, self.xnodot, self.aodp)
 
     def _days_since_1949(self):
         """Date the epoch the way the lunar and solar ephemerides are written."""
@@ -1182,7 +1185,13 @@ class _Keplerians:
         inclination = self._params.xincl + drift["inclination"]
         self.omega += drift["arg_perigee"]
         self._xnode += drift["right_ascension"]
-        self._xmp += drift["mean_anomaly"] + self._mean_longitude_drift
+        self._xmp += drift["mean_anomaly"]
+
+        if deep_space.resonance != NOT_RESONANT:
+            self._mean_motion, self._xmp = deep_space.resonant_correction(
+                self._ts, self._xnode, self.omega, self._params.sidereal_time_at_epoch)
+
+        self._xmp += self._mean_longitude_drift
         self._mean_longitude_drift = 0.0
 
         mean_longitude = np.fmod(self._xmp + self.omega + self._xnode, 2 * np.pi)

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -772,7 +772,22 @@ class _SGDP4:
                 self.omgdot, self.xnodot, self.aodp)
 
     def _days_since_1949(self):
-        """Date the epoch the way the lunar and solar ephemerides are written."""
+        """Date the epoch the way the lunar and solar ephemerides are written.
+
+        Counted straight from the epoch rather than by way of a Julian day, as
+        the article does. A Julian day of the nineteen-nineties is a number
+        around two and a half million, where the doubles either side of it lie
+        forty microseconds apart, so the count that comes back from one is
+        wrong by up to that much. Here it is right to a fraction of a
+        microsecond, against an epoch the element set only states to the
+        nearest millisecond anyway.
+
+        The difference is not quite invisible. It moves where the Sun and the
+        Moon are taken to be, and for an orbit as eccentric as that of the WIND
+        spacecraft, one of the verification satellites, it moves the satellite
+        four micrometres, which is most of the distance between what this
+        computes and what the verification file records.
+        """
         return (self.t_0 - np.datetime64("1949-12-31T00:00:00")) / np.timedelta64(1, "D")
 
     def propagate(self, utc_time):

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -1311,6 +1311,11 @@ class _Keplerians:
         self._temp2 = self._temp1 * self._temp0
 
     def _iterate_newton_raphson(self):
+        """Solve Kepler's equation for the eccentric anomaly.
+
+        A time that has converged is left alone while the others catch up, so
+        that it ends up where it would have had it been asked for by itself.
+        """
         epw = np.fmod(self._xlt - self._xnode, 2 * np.pi)
         # needs a copy in case of an array
         capu = np.array(epw)
@@ -1321,7 +1326,8 @@ class _Keplerians:
             self._ecosE = self._axn * self._cosEPW + self._ayn * self._sinEPW
             self._esinE = self._axn * self._sinEPW - self._ayn * self._cosEPW
             f = capu - epw + self._esinE
-            if np.all(np.abs(f) < NR_EPS):
+            still_converging = np.abs(f) >= NR_EPS
+            if not np.any(still_converging):
                 break
 
             df = 1.0 - self._ecosE
@@ -1333,7 +1339,7 @@ class _Keplerians:
             nr = np.where(np.logical_and(i == 0, np.abs(nr) > 1.25 * self.ecc),
                           np.sign(nr) * self.ecc,
                           f / (df + 0.5 * self._esinE * nr))
-            epw += nr
+            epw = np.where(still_converging, epw + nr, epw)
 
 
     def _update_short_period(self):

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -686,8 +686,8 @@ class OrbitElements:
         return corrected_mean_motion, corrected_semi_major_axis
 
 
-class _SGDP4Base:
-    """Helper class for the SGDP4 computations."""
+class _SGDP4:
+    """The orbit of one satellite, as SGP4 and SDP4 describe it."""
 
     def __init__(self, orbit_elements):
         """Initialize class."""
@@ -774,6 +774,13 @@ class _SGDP4Base:
     def _days_since_1949(self):
         """Date the epoch the way the lunar and solar ephemerides are written."""
         return (self.t_0 - np.datetime64("1949-12-31T00:00:00")) / np.timedelta64(1, "D")
+
+    def propagate(self, utc_time):
+        """Give the Keplerian elements of the orbit at the given time or times."""
+        if self.mode == SGDP4_ZERO_ECC:
+            raise NotImplementedError("Mode SGDP4_ZERO_ECC not implemented")
+
+        return _Keplerians(self).calculate(utc_time)
 
     @property
     def uses_simplified_drag(self):
@@ -888,193 +895,6 @@ class _SGDP4Base:
             (3.0 * self.d3 + self.c1 * (12.0 * self.d2 + 10.0 * c1sq))
         self.t5cof = (0.2 * (3.0 * self.d4 + 12.0 * self.c1 * self.d3 + 6.0 * self.d2**2 +
                                 15.0 * c1sq * (2.0 * self.d2 + c1sq)))
-
-
-class _SGDP4:
-    """Class for SGDP4 computations."""
-
-    def __init__(self, orbital_elements):
-        self._params = _SGDP4Base(orbital_elements)
-
-    @property
-    def eo(self):
-        return self._params.eo
-
-    @property
-    def xincl(self):
-        return self._params.xincl
-
-    @property
-    def xno(self):
-        return self._params.xno
-
-    @property
-    def bstar(self):
-        return self._params.bstar
-
-    @property
-    def omegao(self):
-        return self._params.omegao
-
-    @property
-    def xmo(self):
-        return self._params.xmo
-
-    @property
-    def xnodeo(self):
-        return self._params.xnodeo
-
-    @property
-    def t_0(self):
-        return self._params.t_0
-
-    @property
-    def xn_0(self):
-        return self._params.xn_0
-
-    @property
-    def mode(self):
-        return self._params.mode
-
-    @property
-    def cosIO(self):
-        return self._params.cosIO
-
-    @property
-    def sinIO(self):
-        return self._params.sinIO
-
-    @property
-    def x3thm1(self):
-        return self._params.x3thm1
-
-    @property
-    def x1mth2(self):
-        return self._params.x1mth2
-
-    @property
-    def x7thm1(self):
-        return self._params.x7thm1
-
-    @property
-    def xnodp(self):
-        return self._params.xnodp
-
-    @property
-    def aodp(self):
-        return self._params.aodp
-
-    @property
-    def perigee(self):
-        return self._params.perigee
-
-    @property
-    def apogee(self):
-        return self._params.apogee
-
-    @property
-    def period(self):
-        return self._params.period
-
-    @property
-    def eta(self):
-        return self._params.eta
-
-    @property
-    def c1(self):
-        return self._params.c1
-
-    @property
-    def c2(self):
-        return self._params.c2
-
-    @property
-    def c3(self):
-        return self._params.c3
-
-    @property
-    def c4(self):
-        return self._params.c4
-
-    @property
-    def c5(self):
-        return self._params.c5
-
-    @property
-    def xmdot(self):
-        return self._params.xmdot
-
-    @property
-    def omgdot(self):
-        return self._params.omgdot
-
-    @property
-    def xnodot(self):
-        return self._params.xnodot
-
-    @property
-    def xmcof(self):
-        return self._params.xmcof
-
-    @property
-    def xnodcf(self):
-        return self._params.xnodcf
-
-    @property
-    def t2cof(self):
-        return self._params.t2cof
-
-    @property
-    def xlcof(self):
-        return self._params.xlcof
-
-    @property
-    def aycof(self):
-        return self._params.aycof
-
-    @property
-    def cosXMO(self):
-        return self._params.cosXMO
-
-    @property
-    def sinXMO(self):
-        return self._params.sinXMO
-
-    @property
-    def delmo(self):
-        return self._params.delmo
-
-    @property
-    def d2(self):
-        return self._params.d2
-
-    @property
-    def d3(self):
-        return self._params.d3
-
-    @property
-    def d4(self):
-        return self._params.d4
-
-    @property
-    def t3cof(self):
-        return self._params.t3cof
-
-    @property
-    def t4cof(self):
-        return self._params.t4cof
-
-    @property
-    def t5cof(self):
-        return self._params.t5cof
-
-
-    def propagate(self, utc_time):
-        if self.mode == SGDP4_ZERO_ECC:
-            raise NotImplementedError("Mode SGDP4_ZERO_ECC not implemented")
-
-        kep = _Keplerians(self._params)
-        return kep.calculate(utc_time)
 
 
 class _Keplerians:

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -62,7 +62,6 @@ F = 1 / 298.257223563  # Earth flattening WGS-84
 A = 6378.137  # WGS84 Equatorial radius
 
 
-SGDP4_ZERO_ECC = 0
 SGDP4_DEEP_NORM = 1
 SGDP4_NEAR_SIMP = 2
 SGDP4_NEAR_NORM = 3
@@ -705,10 +704,6 @@ class _SGDP4:
         self.t_0 = orbit_elements.epoch
         self.xn_0 = orbit_elements.mean_motion
 
-        if self.eo < 0:
-            self.mode = self.SGDP4_ZERO_ECC
-            return
-
         self.cosIO = np.cos(self.xincl)
         self.sinIO = np.sin(self.xincl)
         theta2 = self.cosIO**2
@@ -792,9 +787,6 @@ class _SGDP4:
 
     def propagate(self, utc_time):
         """Give the Keplerian elements of the orbit at the given time or times."""
-        if self.mode == SGDP4_ZERO_ECC:
-            raise NotImplementedError("Mode SGDP4_ZERO_ECC not implemented")
-
         return _Keplerians(self).calculate(utc_time)
 
     @property

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -1175,10 +1175,6 @@ class _Keplerians:
         because the wobble is written in terms of the folded angles.
         """
         deep_space = self._params.deep_space
-        if np.size(self._ts) > 1:
-            raise NotImplementedError(
-                "A deep-space satellite can only be propagated to one time at a time")
-
         drift = deep_space.secular_drift(self._ts)
 
         self._eccentricity += drift["eccentricity"]
@@ -1390,9 +1386,10 @@ def _fold_negative_inclination(inclination, right_ascension, arg_perigee):
     A negative inclination describes the same orbit as its positive counterpart
     turned half way around, and the rest of the model expects the latter.
     """
-    if inclination >= 0.0:
-        return inclination, right_ascension, arg_perigee
-    return -inclination, right_ascension + np.pi, arg_perigee - np.pi
+    tipped_over = inclination < 0.0
+    return (np.where(tipped_over, -inclination, inclination),
+            np.where(tipped_over, right_ascension + np.pi, right_ascension),
+            np.where(tipped_over, arg_perigee - np.pi, arg_perigee))
 
 
 def _aycof(sin_inclination):
@@ -1407,8 +1404,7 @@ def _xlcof(sin_inclination, cos_inclination):
     retrograde equatorial orbit drives to zero.
     """
     temp0 = 1.0 + cos_inclination
-    if np.abs(temp0) < EPS_COS:
-        temp0 = np.sign(temp0) * EPS_COS
+    temp0 = np.where(np.abs(temp0) < EPS_COS, np.sign(temp0) * EPS_COS, temp0)
     return 0.125 * A3OVK2 * sin_inclination * (3.0 + 5.0 * cos_inclination) / temp0
 
 

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import optimize
 
 from pyorbital import astronomy, dt2np
+from pyorbital._sgdp4_deep import DeepSpace, apply_periodics
 
 try:
     import dask.array as da
@@ -748,7 +749,7 @@ class _SGDP4Base:
         self.xnodcf = 3.5 * self._betao2 * self._xhdot1 * self.c1
         self.t2cof = 1.5 * self.c1
         self.xlcof = self._calculate_xlcof()
-        self.aycof = 0.25 * A3OVK2 * self.sinIO
+        self.aycof = _aycof(self.sinIO)
         self.cosXMO = np.cos(self.xmo)
         self.sinXMO = np.sin(self.xmo)
         self.delmo = (1.0 + self.eta * self.cosXMO)**3
@@ -761,8 +762,24 @@ class _SGDP4Base:
         self.t5cof = None
         if self.mode == SGDP4_NEAR_NORM:
             self._calculate_near_norm_parameters(tsi, s4)
-        elif self.mode == SGDP4_DEEP_NORM:
-            raise NotImplementedError("Deep space calculations not supported")
+
+        self.deep_space = None
+        if self.mode == SGDP4_DEEP_NORM:
+            self.deep_space = DeepSpace(self._days_since_1949(), self.eo, self.omegao,
+                                        self.xincl, self.xnodeo, self.xnodp)
+
+    def _days_since_1949(self):
+        """Date the epoch the way the lunar and solar ephemerides are written."""
+        return (self.t_0 - np.datetime64("1949-12-31T00:00:00")) / np.timedelta64(1, "D")
+
+    @property
+    def uses_simplified_drag(self):
+        """Tell whether drag is modelled by the simplified equations.
+
+        Those apply to a satellite whose perigee is too low for the full drag
+        expansion to be well behaved, and to every deep-space satellite.
+        """
+        return self.mode != SGDP4_NEAR_NORM
 
     def _calculate_basic_orbit_params(self):
         a1 = (XKE / self.xn_0) ** (2. / 3)
@@ -854,12 +871,7 @@ class _SGDP4Base:
         return 0.0
 
     def _calculate_xlcof(self):
-        # Check for possible divide-by-zero for X/(1+cos(xincl)) when
-        # calculating xlcof */
-        temp0 = 1.0 + self.cosIO
-        if np.abs(temp0) < EPS_COS:
-            temp0 = np.sign(temp0) * EPS_COS
-        return 0.125 * A3OVK2 * self.sinIO * (3.0 + 5.0 * self.cosIO) / temp0
+        return _xlcof(self.sinIO, self.cosIO)
 
     def _calculate_near_norm_parameters(self, tsi, s4):
         c1sq = self.c1**2
@@ -1057,8 +1069,6 @@ class _SGDP4:
     def propagate(self, utc_time):
         if self.mode == SGDP4_ZERO_ECC:
             raise NotImplementedError("Mode SGDP4_ZERO_ECC not implemented")
-        elif self.mode == SGDP4_DEEP_NORM:
-            raise NotImplementedError("Deep space calculations not supported")
 
         kep = _Keplerians(self._params)
         return kep.calculate(utc_time)
@@ -1122,6 +1132,10 @@ class _Keplerians:
         self._calculate_tempe()
         self._calculate_templ()
 
+        self._adopt_orbit_at_epoch()
+        if self._params.deep_space is not None:
+            self._add_lunisolar_perturbations()
+
         self._calculate_a()
         self._calculate_axn_and_ayn()
         self._elsq = _calculate_elsq(self._axn, self._ayn, self._utc_time)
@@ -1134,12 +1148,75 @@ class _Keplerians:
 
         return kep
 
+    def _adopt_orbit_at_epoch(self):
+        """Start from the shape and orientation the elements had at the epoch.
+
+        Only the Sun and the Moon change these, so for a near-earth satellite
+        they stay as they were computed once.
+        """
+        params = self._params
+        self._eccentricity = params.eo
+        self._inclination = params.xincl
+        self._mean_motion = params.xnodp
+        self._semi_major_axis_at_epoch = params.aodp
+        self.sinIO, self.cosIO = params.sinIO, params.cosIO
+        self.x3thm1, self.x1mth2, self.x7thm1 = params.x3thm1, params.x1mth2, params.x7thm1
+        self.aycof, self.xlcof = params.aycof, params.xlcof
+        self._mean_longitude_drift = params.xnodp * self._templ
+
+    def _add_lunisolar_perturbations(self):
+        """Move the orbit the way the Sun and the Moon do.
+
+        Their slow drift is added to the mean elements, then the mean longitude
+        is folded into one turn, and only then is their periodic wobble applied,
+        because the wobble is written in terms of the folded angles.
+        """
+        deep_space = self._params.deep_space
+        if np.size(self._ts) > 1:
+            raise NotImplementedError(
+                "A deep-space satellite can only be propagated to one time at a time")
+
+        drift = deep_space.secular_drift(self._ts)
+
+        self._eccentricity += drift["eccentricity"]
+        inclination = self._params.xincl + drift["inclination"]
+        self.omega += drift["arg_perigee"]
+        self._xnode += drift["right_ascension"]
+        self._xmp += drift["mean_anomaly"] + self._mean_longitude_drift
+        self._mean_longitude_drift = 0.0
+
+        mean_longitude = np.fmod(self._xmp + self.omega + self._xnode, 2 * np.pi)
+        self._xnode = np.fmod(self._xnode, 2 * np.pi)
+        self.omega = np.fmod(self.omega, 2 * np.pi)
+        self._xmp = np.fmod(mean_longitude - self.omega - self._xnode, 2 * np.pi)
+
+        shift = deep_space.periodic_shift(self._ts)
+        (self._eccentricity, inclination, self._xnode, self.omega,
+         self._xmp) = apply_periodics(shift, self._eccentricity, inclination,
+                                      self._xnode, self.omega, self._xmp)
+
+        inclination, self._xnode, self.omega = _fold_negative_inclination(
+            inclination, self._xnode, self.omega)
+        self._adopt_inclination(inclination)
+        self._semi_major_axis_at_epoch = (XKE / self._mean_motion) ** (2.0 / 3)
+
+    def _adopt_inclination(self, inclination):
+        """Recompute what depends on the inclination, which the Moon has moved."""
+        self._inclination = inclination
+        self.sinIO, self.cosIO = np.sin(inclination), np.cos(inclination)
+        theta2 = self.cosIO**2
+        self.x3thm1 = 3.0 * theta2 - 1.0
+        self.x1mth2 = 1.0 - theta2
+        self.x7thm1 = 7.0 * theta2 - 1.0
+        self.aycof = _aycof(self.sinIO)
+        self.xlcof = _xlcof(self.sinIO, self.cosIO)
+
     def _calculate_drag_correction(self):
         """Correct mean anomaly and argument of perigee for drag on the perigee.
 
         The simplified drag equations leave both untouched.
         """
-        if self._params.mode != SGDP4_NEAR_NORM:
+        if self._params.uses_simplified_drag:
             return 0.0
 
         delm = self._params.xmcof * \
@@ -1153,14 +1230,14 @@ class _Keplerians:
         self.omega = self._params.omegao + self._params.omgdot * self._ts - self._temp0
 
     def _calculate_tempe(self):
-        if self._params.mode == SGDP4_NEAR_SIMP:
+        if self._params.uses_simplified_drag:
             self._tempe = self._params.bstar * self._ts * self._params.c4
         else:
             self._tempe = self._params.bstar * \
                 (self._params.c4 * self._ts + self._params.c5 * (np.sin(self._xmp) - self._params.sinXMO))
 
     def _calculate_templ(self):
-        if self._params.mode == SGDP4_NEAR_SIMP:
+        if self._params.uses_simplified_drag:
             self._templ = self._ts * self._ts * self._params.t2cof
         else:
             self._templ = self._ts * self._ts * \
@@ -1168,14 +1245,14 @@ class _Keplerians:
                 (self._params.t3cof + self._ts * (self._params.t4cof + self._ts * self._params.t5cof)))
 
     def _calculate_a(self):
-        if self._params.mode == SGDP4_NEAR_SIMP:
+        if self._params.uses_simplified_drag:
             tempa = 1.0 - self._ts * self._params.c1
         else:
             tempa = 1.0 - \
                 (self._ts *
                  (self._params.c1 + self._ts * (self._params.d2 + self._ts *
                   (self._params.d3 + self._ts * self._params.d4))))
-        self._a = self._params.aodp * tempa**2
+        self._a = self._semi_major_axis_at_epoch * tempa**2
 
         if np.any(self._a < 1):
             raise Exception("Satellite crashed at time %s", self._utc_time)
@@ -1190,10 +1267,10 @@ class _Keplerians:
 
         self._temp0 = 1.0 / (self._a * beta2)
         self._axn = e * cosOMG
-        self._ayn = e * sinOMG + self._temp0 * self._params.aycof
+        self._ayn = e * sinOMG + self._temp0 * self.aycof
 
     def _calculate_e(self, tempe):
-        e = self._params.eo - tempe
+        e = self._eccentricity - tempe
 
         if np.any(e < ECC_LIMIT_LOW):
             raise ValueError("Satellite modified eccentricity too low: %s < %e"
@@ -1205,8 +1282,8 @@ class _Keplerians:
         return e
 
     def _calculate_preliminary_short_period(self):
-        xl = self._xmp + self.omega + self._xnode + self._params.xnodp * self._templ
-        self._xlt = xl + self._temp0 * self._params.xlcof * self._axn
+        xl = self._xmp + self.omega + self._xnode + self._mean_longitude_drift
+        self._xlt = xl + self._temp0 * self.xlcof * self._axn
 
         self._iterate_newton_raphson()
 
@@ -1255,11 +1332,11 @@ class _Keplerians:
 
 
     def _update_short_period(self):
-        self.rk = self._r * (1.0 - 1.5 * self._temp2 * self._betal * self._params.x3thm1) + \
-            0.5 * self._temp1 * self._params.x1mth2 * self._cos2u
-        self.uk = self._u - 0.25 * self._temp2 * self._params.x7thm1 * self._sin2u
-        self.xnodek = self._xnode + 1.5 * self._temp2 * self._params.cosIO * self._sin2u
-        self.xinc = self._params.xincl + 1.5 * self._temp2 * self._params.cosIO * self._params.sinIO * self._cos2u
+        self.rk = self._r * (1.0 - 1.5 * self._temp2 * self._betal * self.x3thm1) + \
+            0.5 * self._temp1 * self.x1mth2 * self._cos2u
+        self.uk = self._u - 0.25 * self._temp2 * self.x7thm1 * self._sin2u
+        self.xnodek = self._xnode + 1.5 * self._temp2 * self.cosIO * self._sin2u
+        self.xinc = self._inclination + 1.5 * self._temp2 * self.cosIO * self.sinIO * self._cos2u
 
         if np.any(self.rk < 1):
             raise Exception("Satellite crashed at time %s", self._utc_time)
@@ -1268,10 +1345,10 @@ class _Keplerians:
         temp2 = XKE / (self._a * self._temp0)
         self.rdotk = (
             (XKE * self._temp0 * self._esinE * self._invR -
-                temp2 * self._temp1 * self._params.x1mth2 * self._sin2u) *
+                temp2 * self._temp1 * self.x1mth2 * self._sin2u) *
             (XKMPER / AE * XMNPDA / 86400.0))
         self.rfdotk = ((XKE * np.sqrt(self._pl) * self._invR + temp2 * self._temp1 *
-                   (self._params.x1mth2 * self._cos2u + 1.5 * self._params.x3thm1)) *
+                   (self.x1mth2 * self._cos2u + 1.5 * self.x3thm1)) *
                   (XKMPER / AE * XMNPDA / 86400.0))
 
     def _collect_return_values(self):
@@ -1296,6 +1373,34 @@ def _check_orbital_elements(orbit_elements):
         raise OrbitalError("Mean motion out of range: %e" % orbit_elements.original_mean_motion)
     if not (0 < orbit_elements.inclination < np.pi):
         raise OrbitalError("Inclination out of range: %e" % orbit_elements.inclination)
+
+
+def _fold_negative_inclination(inclination, right_ascension, arg_perigee):
+    """Bring an orbit the perturbations tipped past the equator back the right way up.
+
+    A negative inclination describes the same orbit as its positive counterpart
+    turned half way around, and the rest of the model expects the latter.
+    """
+    if inclination >= 0.0:
+        return inclination, right_ascension, arg_perigee
+    return -inclination, right_ascension + np.pi, arg_perigee - np.pi
+
+
+def _aycof(sin_inclination):
+    """Give the coefficient of the long period periodic in the y direction."""
+    return 0.25 * A3OVK2 * sin_inclination
+
+
+def _xlcof(sin_inclination, cos_inclination):
+    """Give the coefficient of the long period periodic in the mean longitude.
+
+    The expression divides by one plus the cosine of the inclination, which a
+    retrograde equatorial orbit drives to zero.
+    """
+    temp0 = 1.0 + cos_inclination
+    if np.abs(temp0) < EPS_COS:
+        temp0 = np.sign(temp0) * EPS_COS
+    return 0.125 * A3OVK2 * sin_inclination * (3.0 + 5.0 * cos_inclination) / temp0
 
 
 def _calculate_elsq(axn, ayn, utc_time):

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -37,14 +37,22 @@ NR_EPS = 1.0e-12
 
 CK2 = 5.413080e-4
 CK4 = 0.62098875e-6
-E6A = 1.0e-6
-QOMS2T = 1.88027916e-9
-S = 1.01222928
 S0 = 78.0
 XJ3 = -0.253881e-5
-XKE = 0.743669161e-1
 XKMPER = 6378.135
+XMU = 398600.8  # Earth gravitational parameter, km**3/s**2, WGS-72
 XMNPDA = 1440.0
+
+# Spacetrack Report #3 prints these two as decimals rounded to nine digits.
+# That is not enough: the rounding of the mean motion constant carries into the
+# semi-major axis, and from there into a difference of two nearly equal
+# altitudes that the atmospheric drag fit raises to the fourth power. For a
+# satellite whose perigee is low enough for that fit to apply, the amplified
+# error moves the position half a metre along track over a day, ten times the
+# accuracy the model is verified to. Compute them instead.
+SECONDS_PER_MINUTE = 60.0
+XKE = SECONDS_PER_MINUTE / np.sqrt(XKMPER**3 / XMU)
+QOMS2T = ((120.0 - S0) / XKMPER)**4
 # MFACTOR = 7.292115E-5
 AE = 1.0
 SECDAY = 8.6400E4
@@ -1049,7 +1057,7 @@ class _SGDP4:
     def propagate(self, utc_time):
         if self.mode == SGDP4_ZERO_ECC:
             raise NotImplementedError("Mode SGDP4_ZERO_ECC not implemented")
-        elif self.mode != SGDP4_NEAR_NORM:
+        elif self.mode == SGDP4_DEEP_NORM:
             raise NotImplementedError("Deep space calculations not supported")
 
         kep = _Keplerians(self._params)
@@ -1107,9 +1115,7 @@ class _Keplerians:
         self._xmp = self._params.xmo + self._params.xmdot * self._ts
         self._xnode = self._params.xnodeo + self._ts * (self._params.xnodot + self._ts * self._params.xnodcf)
 
-        delm = self._params.xmcof * \
-            ((1.0 + self._params.eta * np.cos(self._xmp))**3 - self._params.delmo)
-        self._temp0 = self._ts * self._params.omgcof + delm
+        self._temp0 = self._calculate_drag_correction()
         self._xmp += self._temp0
 
         self._calculate_omega()
@@ -1127,6 +1133,18 @@ class _Keplerians:
         kep = self._collect_return_values()
 
         return kep
+
+    def _calculate_drag_correction(self):
+        """Correct mean anomaly and argument of perigee for drag on the perigee.
+
+        The simplified drag equations leave both untouched.
+        """
+        if self._params.mode != SGDP4_NEAR_NORM:
+            return 0.0
+
+        delm = self._params.xmcof * \
+            ((1.0 + self._params.eta * np.cos(self._xmp))**3 - self._params.delmo)
+        return self._ts * self._params.omgcof + delm
 
     def _get_timedelta_in_minutes(self):
         self._ts = (dt2np(self._utc_time) - self._params.t_0) / np.timedelta64(1, "m")

--- a/pyorbital/tests/bench_propagation.py
+++ b/pyorbital/tests/bench_propagation.py
@@ -91,3 +91,71 @@ def test_bench_orbital_init(benchmark):
 
     pos, vel = orbital.get_position(_T0, False)
     _assert_plausible_positions(pos)
+
+
+# MOLNIYA 2-14, whose twelve hour orbit resonates with the Earth's rotation and
+# so has to be followed step by step, and a deep-space orbit that does not.
+_RESONANT_TLE1 = "1 08195U 75081A   06176.33215444  .00000099  00000-0  11873-3 0   813"
+_RESONANT_TLE2 = "2 08195  64.1586 279.0717 6877146 264.7651  20.2257  2.00491383225656"
+_NON_RESONANT_TLE1 = "1 23177U 94040C   06175.45752052  .00000386  00000-0  76590-3 0    95"
+_NON_RESONANT_TLE2 = "2 23177   7.0496 179.8238 7258491 296.0482   8.3061  2.25906668 97438"
+
+
+@pytest.fixture(scope="module")
+def resonant_orbital():
+    """A deep-space satellite whose resonance is integrated step by step."""
+    from pyorbital.orbital import Orbital
+    return Orbital("MOLNIYA 2-14", line1=_RESONANT_TLE1, line2=_RESONANT_TLE2)
+
+
+@pytest.fixture(scope="module")
+def non_resonant_orbital():
+    """A deep-space satellite the Sun and Moon move but the Earth does not beat against."""
+    from pyorbital.orbital import Orbital
+    return Orbital("ARIANE 42P", line1=_NON_RESONANT_TLE1, line2=_NON_RESONANT_TLE2)
+
+
+def _assert_plausible_deep_space(pos):
+    """Guard against silently timing a wrong result, out where the orbits are wide."""
+    radius = np.sqrt(np.sum(np.asarray(pos) ** 2, axis=0))
+    assert np.all(np.isfinite(radius))
+    assert np.all(radius > 6378.0)
+
+
+def _one_day_from(epoch):
+    """A day of propagation times starting at a satellite's own epoch.
+
+    A resonant orbit is followed in steps of twelve hours from its epoch, so
+    what it costs to propagate depends on how far from that epoch it is asked
+    about, not only on how many times are asked for. An element set is normally
+    used within days of its epoch; measuring it twenty years out would time the
+    fourteen thousand steps of the march rather than the propagation.
+    """
+    offsets = np.linspace(0, 86400, _VECTOR_POINTS)
+    return epoch + (offsets * 1e6).astype("timedelta64[us]")
+
+
+def test_bench_deep_space_scalar(benchmark, non_resonant_orbital):
+    """Benchmark: single deep-space propagation."""
+    epoch = non_resonant_orbital.tle.epoch
+    pos, vel = benchmark(non_resonant_orbital.get_position, epoch, False)
+
+    _assert_plausible_deep_space(pos)
+
+
+def test_bench_deep_space_vector_day(benchmark, non_resonant_orbital):
+    """Benchmark: a day of deep-space propagations as one array."""
+    times = _one_day_from(non_resonant_orbital.tle.epoch)
+    pos, vel = benchmark(non_resonant_orbital.get_position, times, False)
+
+    assert np.asarray(pos).shape == (3, _VECTOR_POINTS)
+    _assert_plausible_deep_space(pos)
+
+
+def test_bench_resonant_deep_space_vector_day(benchmark, resonant_orbital):
+    """Benchmark: a day of propagations of a resonant orbit, integrated step by step."""
+    times = _one_day_from(resonant_orbital.tle.epoch)
+    pos, vel = benchmark(resonant_orbital.get_position, times, False)
+
+    assert np.asarray(pos).shape == (3, _VECTOR_POINTS)
+    _assert_plausible_deep_space(pos)

--- a/pyorbital/tests/bench_propagation.py
+++ b/pyorbital/tests/bench_propagation.py
@@ -1,0 +1,83 @@
+"""Benchmarks for SGP4/SDP4 orbit propagation.
+
+Run with::
+
+    pytest pyorbital/tests/bench_propagation.py --benchmark-only -v
+
+Record a baseline before changing the propagator::
+
+    pytest pyorbital/tests/bench_propagation.py --benchmark-only --benchmark-save=pre-sdp4
+
+and compare later work against it::
+
+    pytest pyorbital/tests/bench_propagation.py --benchmark-only \
+        --benchmark-compare=pre-sdp4 --benchmark-compare-fail=median:8%
+
+Three near-earth scenarios establish the reference cost of the existing SGP4
+path: a single propagation (per-call overhead), a day of propagations as one
+array (vectorised throughput), and construction of an ``Orbital`` object (TLE
+parsing plus the one-off ``_SGDP4Base`` coefficient computation).
+"""
+
+import datetime as dt
+
+import numpy as np
+import pytest
+
+# FY-3F, epoch 2026-04-01. Near-earth (~100 min period), the common LEO case.
+_TLE1 = "1 57490U 23111A   26091.51900704  .00000079  00000+0  57513-4 0  9997"
+_TLE2 = "2 57490  98.6883 162.9408 0000839  82.8428 277.2844 14.19924724137986"
+_T0 = dt.datetime(2026, 4, 1, 12, 0, 0)
+
+_VECTOR_POINTS = 10000
+
+
+@pytest.fixture(scope="module")
+def near_earth_orbital():
+    """Pre-built Orbital object, so construction cost stays out of the timing."""
+    from pyorbital.orbital import Orbital
+    return Orbital("FY-3F", line1=_TLE1, line2=_TLE2)
+
+
+@pytest.fixture(scope="module")
+def one_day_of_times():
+    """A day of propagation times, evenly spaced, as a datetime64 array."""
+    start = np.datetime64(_T0)
+    offsets = np.linspace(0, 86400, _VECTOR_POINTS)
+    return start + (offsets * 1e6).astype("timedelta64[us]")
+
+
+def _construct_orbital():
+    from pyorbital.orbital import Orbital
+    return Orbital("FY-3F", line1=_TLE1, line2=_TLE2)
+
+
+def _assert_plausible_positions(pos):
+    """Guard against silently timing a wrong result."""
+    radius = np.sqrt(np.sum(np.asarray(pos) ** 2, axis=0))
+    assert np.all(np.isfinite(radius))
+    assert np.all(radius > 6378.0)
+    assert np.all(radius < 7500.0)
+
+
+def test_bench_near_earth_scalar(benchmark, near_earth_orbital):
+    """Benchmark: single near-earth propagation (per-call overhead)."""
+    pos, vel = benchmark(near_earth_orbital.get_position, _T0, False)
+
+    _assert_plausible_positions(pos)
+
+
+def test_bench_near_earth_vector_day(benchmark, near_earth_orbital, one_day_of_times):
+    """Benchmark: a day of near-earth propagations as one array."""
+    pos, vel = benchmark(near_earth_orbital.get_position, one_day_of_times, False)
+
+    assert np.asarray(pos).shape == (3, _VECTOR_POINTS)
+    _assert_plausible_positions(pos)
+
+
+def test_bench_orbital_init(benchmark):
+    """Benchmark: Orbital construction (TLE parsing and orbit coefficients)."""
+    orbital = benchmark(_construct_orbital)
+
+    pos, vel = orbital.get_position(_T0, False)
+    _assert_plausible_positions(pos)

--- a/pyorbital/tests/bench_propagation.py
+++ b/pyorbital/tests/bench_propagation.py
@@ -4,14 +4,24 @@ Run with::
 
     pytest pyorbital/tests/bench_propagation.py --benchmark-only -v
 
-Record a baseline before changing the propagator::
+To judge whether a change costs anything, measure both versions back to back in
+the same session::
 
-    pytest pyorbital/tests/bench_propagation.py --benchmark-only --benchmark-save=pre-sdp4
+    git stash push pyorbital/orbital.py
+    pytest pyorbital/tests/bench_propagation.py --benchmark-only --benchmark-save=before
+    git stash pop
+    pytest pyorbital/tests/bench_propagation.py --benchmark-only --benchmark-compare=before
 
-and compare later work against it::
+Comparing against a baseline saved earlier does not work: these timings drift by
+tens of percent between sessions on an otherwise idle machine, which is several
+times larger than the effects worth detecting here. A saved baseline that is
+minutes old is already worthless as an absolute reference.
 
-    pytest pyorbital/tests/bench_propagation.py --benchmark-only \
-        --benchmark-compare=pre-sdp4 --benchmark-compare-fail=median:8%
+Even back to back the noise is large. Four consecutive runs of identical code
+gave scalar medians of 56, 81, 70 and 60 microseconds, a spread of 44%. Treat a
+single pair of runs as able to show only that a change is not catastrophic. To
+judge anything finer, interleave several runs of each version and compare the
+distributions, or pin the CPU frequency first.
 
 Three near-earth scenarios establish the reference cost of the existing SGP4
 path: a single propagation (per-call overhead), a day of propagations as one

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -1,127 +1,197 @@
-"""Test cases from the AIAA article."""
+"""Verification of the propagator against the AIAA 2006-6753 test cases.
 
+The satellites of ``SGP4-VER.TLE`` are propagated to every time for which
+``aiaa_results`` gives an expected state, and the two are compared.
 
-# TODO: right formal unit tests.
-from __future__ import print_function, with_statement
+Satellites that the propagator cannot handle yet are listed in
+``NOT_YET_SUPPORTED``; removing a satellite from that set turns its test back
+on. Satellites that are not expected to ever pass are listed in
+``SKIP_DECAYING`` with a reason. ``test_every_reference_satellite_is_accounted_for``
+makes sure no satellite silently escapes all three treatments.
+"""
 
 import datetime as dt
 import os
-import unittest
+from dataclasses import dataclass
 
 import numpy as np
+import pytest
 
-from pyorbital import astronomy, tlefile
-from pyorbital.orbital import _SGDP4, Orbital, OrbitElements
+from pyorbital import astronomy
+from pyorbital.orbital import Orbital
 from pyorbital.tlefile import ChecksumError
 
-
-class LineOrbital(Orbital):
-    """Read TLE lines instead of file."""
-
-    def __init__(self, satellite, line1, line2):
-        """Initialize the class."""
-        satellite = satellite.upper()
-        self.satellite_name = satellite
-        self.tle = tlefile.read(satellite, line1=line1, line2=line2)
-        self.orbit_elements = OrbitElements(self.tle)
-        self._sgdp4 = _SGDP4(self.orbit_elements)
-
-
-def get_results(satnumber, delay):
-    """Get expected results from result file."""
-    path = os.path.dirname(os.path.abspath(__file__))
-    with open(os.path.join(path, "aiaa_results")) as f_2:
-        line = f_2.readline()
-        while line:
-            if line.endswith(" xx\n") and int(line[:-3]) == satnumber:
-                line = f_2.readline()
-                while (not line.startswith("%.8f" % delay)):
-                    line = f_2.readline()
-                sline = line.split()
-                if delay == 0:
-                    utc_time = None
-                else:
-                    utc_time = dt.datetime.strptime(sline[-1], "%H:%M:%S.%f")
-                    utc_time = utc_time.replace(year=int(sline[-4]),
-                                                month=int(sline[-3]),
-                                                day=int(sline[-2]))
-                    utc_time = np.datetime64(utc_time)
-                return (float(sline[1]),
-                        float(sline[2]),
-                        float(sline[3]),
-                        float(sline[4]),
-                        float(sline[5]),
-                        float(sline[6]),
-                        utc_time)
-            line = f_2.readline()
-
-
 _DATAPATH = os.path.dirname(os.path.abspath(__file__))
+_TLE_FILE = os.path.join(_DATAPATH, "SGP4-VER.TLE")
+_REFERENCE_FILE = os.path.join(_DATAPATH, "aiaa_results")
+
+POSITION_TOLERANCE = 5e-6  # km
+VELOCITY_TOLERANCE = 5e-9  # km/s
+TIME_TOLERANCE = 1e-3  # minutes
+
+CHECKSUM_ERROR_SATELLITES = {33333, 33334, 33335}
+
+SKIP_DECAYING = {
+    29141: "SL-14 DEB is on its last orbits; decay is not modelled, and the "
+           "propagated position drifts ~0.3 mm/min away from the reference",
+}
+
+NOT_YET_SUPPORTED = {
+    # Near-earth, simplified drag equations: rejected by _SGDP4.propagate.
+    88888, 29238, 28350, 22312, 28872,
+    # Deep space, non-resonant.
+    28129, 16925, 28623, 23177, 23599, 4632, 20413, 11801, 23333,
+    # Deep space, 12 h resonance.
+    9880, 8195, 26975, 21897, 22674,
+    # Deep space, 24 h (geosynchronous) resonance.
+    24208, 9998, 28626, 26900, 25954, 14128,
+}
 
 
-class AIAAIntegrationTest(unittest.TestCase):
-    """Test against the AIAA test cases."""
+@dataclass(frozen=True)
+class ReferenceState:
+    """One expected state vector from ``aiaa_results``."""
 
-    @unittest.skipIf(
-        not os.path.exists(os.path.join(_DATAPATH, "SGP4-VER.TLE")),
-        "SGP4-VER.TLE not available")
-    def test_aiaa(self):
-        """Do the tests against AIAA test cases."""
-        path = os.path.dirname(os.path.abspath(__file__))
-        with open(os.path.join(path, "SGP4-VER.TLE")) as f__:
-            test_line = f__.readline()
-            while test_line:
-                if test_line.startswith("#"):
-                    test_name = test_line
-                if test_line.startswith("1 "):
-                    line1 = test_line
-                if test_line.startswith("2 "):
-                    _check_line2(f__, test_name, line1, test_line)
-
-                test_line = f__.readline()
+    position: tuple[float, float, float]
+    velocity: tuple[float, float, float]
+    utc_time: np.datetime64 | None
 
 
-def _check_line2(f__, test_name: str, line1: str, test_line: str) -> None:
-    line2 = test_line[:69]
-    times_str = str.split(test_line[69:])
-    times = np.arange(float(times_str[0]),
-                      float(times_str[1]) + 1,
-                      float(times_str[2]))
-    if test_name.startswith("#   SL-14 DEB"):
-        # FIXME: we have to handle decaying satellites!
-        return
+@dataclass(frozen=True)
+class VerificationCase:
+    """One satellite of ``SGP4-VER.TLE``.
 
-    try:
-        o = LineOrbital("unknown", line1, line2)
-    except NotImplementedError:
-        return
-    except ChecksumError:
-        assert test_line.split()[1] in ["33333", "33334", "33335"]
-        return
+    The delays to propagate to are not taken from the trailing start/stop/step
+    of line 2 but from the reference file, which is the authority on which
+    states are actually defined: for satellites that decay during the requested
+    span the reference stops early, and one satellite asks for a second span
+    that the reference does not cover at all.
+    """
 
-    for delay in times:
-        try:
-            test_time = delay.astype("timedelta64[m]") + o.tle.epoch
-            pos, vel = o.get_position(test_time, False)
-            res = get_results(
-                int(o.tle.satnumber), float(delay))
-        except NotImplementedError:
-            # Skipping deep-space
-            break
-        # except ValueError, e:
-        #     from warnings import warn
-        #     warn(test_name + ' ' + str(e))
-        #     break
+    satnumber: int
+    name: str
+    line1: str
+    line2: str
 
-        delta_pos = 5e-6  # km =  5 mm
-        delta_vel = 5e-9  # km/s = 5 um/s
-        delta_time = 1e-3  # 1 millisecond
-        assert abs(res[0] - pos[0]) < delta_pos
-        assert abs(res[1] - pos[1]) < delta_pos
-        assert abs(res[2] - pos[2]) < delta_pos
-        assert abs(res[3] - vel[0]) < delta_vel
-        assert abs(res[4] - vel[1]) < delta_vel
-        assert abs(res[5] - vel[2]) < delta_vel
-        if res[6] is not None:
-            dt = astronomy._days(res[6] - test_time) * 24 * 60
-            assert abs(dt) < delta_time
+
+def _delay_key(delay):
+    """Key a delay by its printed value, so accumulated float error cannot miss a row."""
+    return f"{float(delay):.8f}"
+
+
+def _parse_reference_states(path):
+    """Read all expected state vectors, keyed by satellite number and delay."""
+    states: dict[int, dict[str, ReferenceState]] = {}
+    with open(path) as reference_file:
+        for line in reference_file:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.endswith(" xx"):
+                states[int(line[:-3])] = current_satellite = {}
+                continue
+            fields = line.split()
+            current_satellite[_delay_key(fields[0])] = ReferenceState(
+                position=(float(fields[1]), float(fields[2]), float(fields[3])),
+                velocity=(float(fields[4]), float(fields[5]), float(fields[6])),
+                utc_time=_parse_reference_time(fields[7:]),
+            )
+    return states
+
+
+def _parse_reference_time(fields):
+    """Read the trailing ``year mon day hh:mm:ss.ssssss`` fields, if present."""
+    if not fields:
+        return None
+    year, month, day, time_of_day = fields
+    utc_time = dt.datetime.strptime(time_of_day, "%H:%M:%S.%f")
+    return np.datetime64(utc_time.replace(year=int(year), month=int(month), day=int(day)))
+
+
+def _parse_verification_cases(path):
+    """Read the satellites to propagate and the delays requested for each.
+
+    A satellite may appear more than once, asking for a further span of delays
+    that the reference file does not cover; only its first appearance is kept.
+    """
+    cases = {}
+    name = ""
+    line1 = ""
+    with open(path) as tle_file:
+        for line in tle_file:
+            line = line.rstrip("\r\n")
+            if line.startswith("#"):
+                name = line
+            elif line.startswith("1 "):
+                line1 = line
+            elif line.startswith("2 "):
+                line2 = line[:69]
+                case = VerificationCase(satnumber=int(line2[2:7]), name=name,
+                                        line1=line1, line2=line2)
+                cases.setdefault(case.satnumber, case)
+    return cases
+
+
+REFERENCE_STATES = _parse_reference_states(_REFERENCE_FILE)
+VERIFICATION_CASES = _parse_verification_cases(_TLE_FILE)
+
+PROPAGATION_CASES = sorted(set(VERIFICATION_CASES) - CHECKSUM_ERROR_SATELLITES)
+
+
+def _reference_delays(satnumber):
+    """The delays, in minutes, for which the reference file defines a state."""
+    return sorted(float(delay) for delay in REFERENCE_STATES[satnumber])
+
+
+def _describe(satnumber, delay):
+    """Name a satellite and time the way the verification file comments on it."""
+    description = VERIFICATION_CASES[satnumber].name.lstrip("#").strip()
+    return f"{satnumber} ({description}) at {delay} min"
+
+
+def _assert_matches_reference(satnumber, delay, utc_time, position, velocity):
+    """Compare one propagated state against its reference value."""
+    expected = REFERENCE_STATES[satnumber][_delay_key(delay)]
+
+    np.testing.assert_allclose(position, expected.position, atol=POSITION_TOLERANCE, rtol=0,
+                               err_msg=f"position of {_describe(satnumber, delay)}")
+    np.testing.assert_allclose(velocity, expected.velocity, atol=VELOCITY_TOLERANCE, rtol=0,
+                               err_msg=f"velocity of {_describe(satnumber, delay)}")
+
+    if expected.utc_time is not None:
+        error_in_minutes = astronomy._days(expected.utc_time - utc_time) * 24 * 60
+        assert abs(error_in_minutes) < TIME_TOLERANCE
+
+
+@pytest.mark.parametrize("satnumber", PROPAGATION_CASES, ids=str)
+def test_aiaa_verification_case(satnumber):
+    """Propagated states match the AIAA reference values."""
+    if satnumber in SKIP_DECAYING:
+        pytest.skip(SKIP_DECAYING[satnumber])
+    if satnumber in NOT_YET_SUPPORTED:
+        pytest.skip(f"{satnumber} is not supported by the propagator yet")
+
+    case = VERIFICATION_CASES[satnumber]
+    orbital = Orbital("unknown", line1=case.line1, line2=case.line2)
+
+    for delay in _reference_delays(satnumber):
+        utc_time = np.timedelta64(round(delay * 60 * 1e6), "us") + orbital.tle.epoch
+        position, velocity = orbital.get_position(utc_time, normalize=False)
+        _assert_matches_reference(satnumber, delay, utc_time, position, velocity)
+
+
+@pytest.mark.parametrize("satnumber", sorted(CHECKSUM_ERROR_SATELLITES), ids=str)
+def test_aiaa_case_with_broken_checksum_is_rejected(satnumber):
+    """Deliberately corrupted verification TLEs are rejected when read."""
+    case = VERIFICATION_CASES[satnumber]
+
+    with pytest.raises(ChecksumError):
+        Orbital("unknown", line1=case.line1, line2=case.line2)
+
+
+def test_every_reference_satellite_is_accounted_for():
+    """No satellite of the reference file escapes both testing and an explicit skip."""
+    assert set(REFERENCE_STATES) == set(PROPAGATION_CASES)
+    assert SKIP_DECAYING.keys() <= set(PROPAGATION_CASES)
+    assert NOT_YET_SUPPORTED <= set(PROPAGATION_CASES)
+    assert not NOT_YET_SUPPORTED & SKIP_DECAYING.keys()

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -190,18 +190,13 @@ def test_every_reference_satellite_is_propagated():
     assert not set(PROPAGATION_CASES) & CHECKSUM_ERROR_SATELLITES
 
 
-# Asking for many times at once does not give bit for bit what asking for each
-# one gives. Kepler's equation is solved by iterating until every time in the
-# array has converged, so the ones that converge first take a few more turns of
-# a loop that has all but stopped moving them, and their last bits differ. The
-# two agree far more closely than the model is verified to, which is what this
-# checks; removing the shared stopping test makes them agree exactly.
-AT_ONCE_TOLERANCE = 1e-6  # km
-
-
 @pytest.mark.parametrize("satnumber", PROPAGATION_CASES, ids=str)
 def test_propagating_to_all_the_times_at_once_agrees(satnumber):
-    """Every satellite gives the same states whether asked one time or all at once."""
+    """Every satellite gives the same states whether asked one time or all at once.
+
+    Exactly the same states: a time asked for alongside others must not come out
+    even a bit differently from the same time asked for alone.
+    """
     case = VERIFICATION_CASES[satnumber]
     orbital = Orbital("unknown", line1=case.line1, line2=case.line2)
     delays = _reference_delays(satnumber)
@@ -211,7 +206,5 @@ def test_propagating_to_all_the_times_at_once_agrees(satnumber):
     at_once = orbital.get_position(times, normalize=False)
     one_by_one = [orbital.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_allclose(at_once[0], np.array([p for p, _ in one_by_one]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
-    np.testing.assert_allclose(at_once[1], np.array([v for _, v in one_by_one]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_array_equal(at_once[0], np.array([p for p, _ in one_by_one]).T)
+    np.testing.assert_array_equal(at_once[1], np.array([v for _, v in one_by_one]).T)

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -30,9 +30,13 @@ TIME_TOLERANCE = 1e-3  # minutes
 
 CHECKSUM_ERROR_SATELLITES = {33333, 33334, 33335}
 
+# UTC gained a leap second at the end of 2005. The reference file prints
+# calendar times that count it, while the propagator counts uniform minutes
+# from the epoch and knows nothing of it, so the two part company by exactly one
+# second as soon as a satellite is propagated across the turn of that year.
+LEAP_SECONDS = (np.datetime64("2006-01-01T00:00:00"),)
+
 NOT_YET_SUPPORTED = {
-    # Deep space, non-resonant.
-    28129, 16925, 28623, 23177, 23599, 4632, 20413, 11801, 23333,
     # Deep space, 12 h resonance.
     9880, 8195, 26975, 21897, 22674,
     # Deep space, 24 h (geosynchronous) resonance.
@@ -141,7 +145,13 @@ def _describe(satnumber, delay):
     return f"{satnumber} ({description}) at {delay} min"
 
 
-def _assert_matches_reference(satnumber, delay, utc_time, position, velocity):
+def _leap_seconds_between(epoch, utc_time):
+    """Count the leap seconds UTC gained while the satellite was propagated."""
+    crossed = sum(1 for leap in LEAP_SECONDS if epoch < leap <= utc_time)
+    return np.timedelta64(crossed, "s")
+
+
+def _assert_matches_reference(satnumber, delay, epoch, utc_time, position, velocity):
     """Compare one propagated state against its reference value."""
     expected = REFERENCE_STATES[satnumber][_delay_key(delay)]
 
@@ -151,7 +161,8 @@ def _assert_matches_reference(satnumber, delay, utc_time, position, velocity):
                                err_msg=f"velocity of {_describe(satnumber, delay)}")
 
     if expected.utc_time is not None:
-        error_in_minutes = astronomy._days(expected.utc_time - utc_time) * 24 * 60
+        expected_time = expected.utc_time + _leap_seconds_between(epoch, utc_time)
+        error_in_minutes = astronomy._days(expected_time - utc_time) * 24 * 60
         assert abs(error_in_minutes) < TIME_TOLERANCE
 
 
@@ -167,7 +178,8 @@ def test_aiaa_verification_case(satnumber):
     for delay in _reference_delays(satnumber):
         utc_time = np.timedelta64(round(delay * 60 * 1e6), "us") + orbital.tle.epoch
         position, velocity = orbital.get_position(utc_time, normalize=False)
-        _assert_matches_reference(satnumber, delay, utc_time, position, velocity)
+        _assert_matches_reference(satnumber, delay, orbital.tle.epoch, utc_time,
+                                  position, velocity)
 
 
 @pytest.mark.parametrize("satnumber", sorted(CHECKSUM_ERROR_SATELLITES), ids=str)

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -188,3 +188,30 @@ def test_every_reference_satellite_is_propagated():
     """
     assert set(REFERENCE_STATES) == set(PROPAGATION_CASES)
     assert not set(PROPAGATION_CASES) & CHECKSUM_ERROR_SATELLITES
+
+
+# Asking for many times at once does not give bit for bit what asking for each
+# one gives. Kepler's equation is solved by iterating until every time in the
+# array has converged, so the ones that converge first take a few more turns of
+# a loop that has all but stopped moving them, and their last bits differ. The
+# two agree far more closely than the model is verified to, which is what this
+# checks; removing the shared stopping test makes them agree exactly.
+AT_ONCE_TOLERANCE = 1e-6  # km
+
+
+@pytest.mark.parametrize("satnumber", PROPAGATION_CASES, ids=str)
+def test_propagating_to_all_the_times_at_once_agrees(satnumber):
+    """Every satellite gives the same states whether asked one time or all at once."""
+    case = VERIFICATION_CASES[satnumber]
+    orbital = Orbital("unknown", line1=case.line1, line2=case.line2)
+    delays = _reference_delays(satnumber)
+
+    times = np.array([np.timedelta64(round(delay * 60 * 1e6), "us") + orbital.tle.epoch
+                      for delay in delays])
+    at_once = orbital.get_position(times, normalize=False)
+    one_by_one = [orbital.get_position(time, normalize=False) for time in times]
+
+    np.testing.assert_allclose(at_once[0], np.array([p for p, _ in one_by_one]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(at_once[1], np.array([v for _, v in one_by_one]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -3,10 +3,8 @@
 The satellites of ``SGP4-VER.TLE`` are propagated to every time for which
 ``aiaa_results`` gives an expected state, and the two are compared.
 
-Satellites the propagator does not get right yet are listed in
-``NOT_YET_SUPPORTED``; removing a satellite from that set turns its test back
-on. ``test_every_reference_satellite_is_accounted_for`` makes sure no satellite
-silently escapes both testing and that list.
+Every satellite of the reference file is propagated, and
+``test_every_reference_satellite_is_propagated`` keeps it that way.
 """
 
 import datetime as dt
@@ -37,9 +35,7 @@ CHECKSUM_ERROR_SATELLITES = {33333, 33334, 33335}
 LEAP_SECONDS = (np.datetime64("2006-01-01T00:00:00"),)
 
 NOT_YET_SUPPORTED = {
-    # Deep space, 12 h resonance.
-    9880, 8195, 26975, 21897, 22674,
-    # Deep space, 24 h (geosynchronous) resonance.
+    # Deep space, resonating once a day.
     24208, 9998, 28626, 26900, 25954, 14128,
 }
 
@@ -191,7 +187,13 @@ def test_aiaa_case_with_broken_checksum_is_rejected(satnumber):
         Orbital("unknown", line1=case.line1, line2=case.line2)
 
 
-def test_every_reference_satellite_is_accounted_for():
-    """No satellite of the reference file escapes both testing and an explicit skip."""
+def test_every_reference_satellite_is_propagated():
+    """Every satellite the reference file describes is propagated and checked.
+
+    Nothing may be quietly left out: a satellite of the reference file either
+    has its states compared here or is one of the deliberately corrupted element
+    sets, which are checked to be rejected instead.
+    """
     assert set(REFERENCE_STATES) == set(PROPAGATION_CASES)
+    assert not set(PROPAGATION_CASES) & CHECKSUM_ERROR_SATELLITES
     assert NOT_YET_SUPPORTED <= set(PROPAGATION_CASES)

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -3,11 +3,10 @@
 The satellites of ``SGP4-VER.TLE`` are propagated to every time for which
 ``aiaa_results`` gives an expected state, and the two are compared.
 
-Satellites that the propagator cannot handle yet are listed in
+Satellites the propagator does not get right yet are listed in
 ``NOT_YET_SUPPORTED``; removing a satellite from that set turns its test back
-on. Satellites that are not expected to ever pass are listed in
-``SKIP_DECAYING`` with a reason. ``test_every_reference_satellite_is_accounted_for``
-makes sure no satellite silently escapes all three treatments.
+on. ``test_every_reference_satellite_is_accounted_for`` makes sure no satellite
+silently escapes both testing and that list.
 """
 
 import datetime as dt
@@ -31,14 +30,7 @@ TIME_TOLERANCE = 1e-3  # minutes
 
 CHECKSUM_ERROR_SATELLITES = {33333, 33334, 33335}
 
-SKIP_DECAYING = {
-    29141: "SL-14 DEB is on its last orbits; decay is not modelled, and the "
-           "propagated position drifts ~0.3 mm/min away from the reference",
-}
-
 NOT_YET_SUPPORTED = {
-    # Near-earth, simplified drag equations: rejected by _SGDP4.propagate.
-    88888, 29238, 28350, 22312, 28872,
     # Deep space, non-resonant.
     28129, 16925, 28623, 23177, 23599, 4632, 20413, 11801, 23333,
     # Deep space, 12 h resonance.
@@ -166,8 +158,6 @@ def _assert_matches_reference(satnumber, delay, utc_time, position, velocity):
 @pytest.mark.parametrize("satnumber", PROPAGATION_CASES, ids=str)
 def test_aiaa_verification_case(satnumber):
     """Propagated states match the AIAA reference values."""
-    if satnumber in SKIP_DECAYING:
-        pytest.skip(SKIP_DECAYING[satnumber])
     if satnumber in NOT_YET_SUPPORTED:
         pytest.skip(f"{satnumber} is not supported by the propagator yet")
 
@@ -192,6 +182,4 @@ def test_aiaa_case_with_broken_checksum_is_rejected(satnumber):
 def test_every_reference_satellite_is_accounted_for():
     """No satellite of the reference file escapes both testing and an explicit skip."""
     assert set(REFERENCE_STATES) == set(PROPAGATION_CASES)
-    assert SKIP_DECAYING.keys() <= set(PROPAGATION_CASES)
     assert NOT_YET_SUPPORTED <= set(PROPAGATION_CASES)
-    assert not NOT_YET_SUPPORTED & SKIP_DECAYING.keys()

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -26,6 +26,13 @@ POSITION_TOLERANCE = 5e-6  # km
 VELOCITY_TOLERANCE = 5e-9  # km/s
 TIME_TOLERANCE = 1e-3  # minutes
 
+# Asking for many times at once should give what asking for each one gives. The
+# propagator does, but numpy need not: it may evaluate a sine over an array with
+# different instructions than over a single number, and the two can differ in
+# the last bit. That is far below what is being checked here, so allow for it
+# rather than demanding the two agree exactly.
+AT_ONCE_TOLERANCE = 1e-9  # km
+
 CHECKSUM_ERROR_SATELLITES = {33333, 33334, 33335}
 
 # UTC gained a leap second at the end of 2005. The reference file prints
@@ -194,8 +201,8 @@ def test_every_reference_satellite_is_propagated():
 def test_propagating_to_all_the_times_at_once_agrees(satnumber):
     """Every satellite gives the same states whether asked one time or all at once.
 
-    Exactly the same states: a time asked for alongside others must not come out
-    even a bit differently from the same time asked for alone.
+    A time asked for alongside others must not come out differently from the
+    same time asked for alone.
     """
     case = VERIFICATION_CASES[satnumber]
     orbital = Orbital("unknown", line1=case.line1, line2=case.line2)
@@ -206,5 +213,7 @@ def test_propagating_to_all_the_times_at_once_agrees(satnumber):
     at_once = orbital.get_position(times, normalize=False)
     one_by_one = [orbital.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_array_equal(at_once[0], np.array([p for p, _ in one_by_one]).T)
-    np.testing.assert_array_equal(at_once[1], np.array([v for _, v in one_by_one]).T)
+    np.testing.assert_allclose(at_once[0], np.array([p for p, _ in one_by_one]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(at_once[1], np.array([v for _, v in one_by_one]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)

--- a/pyorbital/tests/test_aiaa.py
+++ b/pyorbital/tests/test_aiaa.py
@@ -34,11 +34,6 @@ CHECKSUM_ERROR_SATELLITES = {33333, 33334, 33335}
 # second as soon as a satellite is propagated across the turn of that year.
 LEAP_SECONDS = (np.datetime64("2006-01-01T00:00:00"),)
 
-NOT_YET_SUPPORTED = {
-    # Deep space, resonating once a day.
-    24208, 9998, 28626, 26900, 25954, 14128,
-}
-
 
 @dataclass(frozen=True)
 class ReferenceState:
@@ -165,9 +160,6 @@ def _assert_matches_reference(satnumber, delay, epoch, utc_time, position, veloc
 @pytest.mark.parametrize("satnumber", PROPAGATION_CASES, ids=str)
 def test_aiaa_verification_case(satnumber):
     """Propagated states match the AIAA reference values."""
-    if satnumber in NOT_YET_SUPPORTED:
-        pytest.skip(f"{satnumber} is not supported by the propagator yet")
-
     case = VERIFICATION_CASES[satnumber]
     orbital = Orbital("unknown", line1=case.line1, line2=case.line2)
 
@@ -196,4 +188,3 @@ def test_every_reference_satellite_is_propagated():
     """
     assert set(REFERENCE_STATES) == set(PROPAGATION_CASES)
     assert not set(PROPAGATION_CASES) & CHECKSUM_ERROR_SATELLITES
-    assert NOT_YET_SUPPORTED <= set(PROPAGATION_CASES)

--- a/pyorbital/tests/test_deep_space_branches.py
+++ b/pyorbital/tests/test_deep_space_branches.py
@@ -25,7 +25,7 @@ import pytest
 
 from pyorbital.orbital import Orbital
 
-POSITION_TOLERANCE = 50e-6  # km, as for the AIAA cases
+POSITION_TOLERANCE = 5e-6  # km, as for the AIAA cases
 
 CASES = {
     "eccentricity above the fit boundary at 0.65": (

--- a/pyorbital/tests/test_deep_space_branches.py
+++ b/pyorbital/tests/test_deep_space_branches.py
@@ -1,0 +1,79 @@
+"""Propagation of deep-space orbits the AIAA verification set does not reach.
+
+The article's satellites leave parts of the deep-space model untried. None of
+its five twelve-hour satellites has an eccentricity between 0.65 and 0.66, where
+one of the fits of the resonance to eccentricity changes over; none has a mean
+motion just below the band where that resonance is held to apply; and all six of
+its geosynchronous satellites are so nearly circular that the eccentricity terms
+of their own fit contribute a millionth of what they could. Altering any of
+those three places in the propagator leaves the AIAA tests passing.
+
+A seventh day is asked for as well as the first, because the beat between a
+resonant orbit and the Earth's rotation is integrated forward from the epoch and
+so builds up with time. A difference in the constants that describe it can be
+too small to show within a day and plain within a week.
+
+The orbits below sit in each of those gaps. Their expected positions come from
+the ``sgp4`` package, a port of the reference implementation the article
+describes, which reproduces every state of ``aiaa_results`` to within five
+nanometres. That package is not needed to run these tests, only to have written
+them.
+"""
+
+import numpy as np
+import pytest
+
+from pyorbital.orbital import Orbital
+
+POSITION_TOLERANCE = 50e-6  # km, as for the AIAA cases
+
+CASES = {
+    "eccentricity above the fit boundary at 0.65": (
+        "1 40001U 06001A   06176.00000000  .00000000  00000+0  00000+0 0  9990",
+        "2 40001  63.4000  45.0000 6550000 120.0000  30.0000  1.99500000    16",
+        (
+            (0.0, (-4663.844135811, -13491.263180781, -12429.628762728)),
+            (360.0, (29673.513675195, 8151.069052328, -30392.205431881)),
+            (1440.0, (-5159.103677060, -13242.779329675, -11423.226602012)),
+            (-720.0, (-4411.288916872, -13600.330410202, -12919.198839071)),
+            (10000.0, (8065.030788060, 12257.077967201, 6233.620791191)),
+        ),
+    ),
+    "mean motion just below the twelve hour resonance band": (
+        "1 40002U 06001A   06176.00000000  .00000000  00000+0  00000+0 0  9991",
+        "2 40002  63.4000  45.0000 6000000 120.0000  30.0000  1.88570000    12",
+        (
+            (0.0, (-7026.383636164, -14550.621581078, -10590.893711190)),
+            (360.0, (29517.980694216, 7079.922133772, -31691.360946876)),
+            (1440.0, (-693.801125596, 6913.594467648, 10737.220017617)),
+            (-720.0, (-1159.549983466, -15907.214392140, -20775.504005053)),
+            (10000.0, (2850.484294481, -15296.203768858, -25754.090168744)),
+        ),
+    ),
+    "geosynchronous and eccentric enough to feel its own fit": (
+        "1 40003U 06001A   06176.00000000  .00000000  00000+0  00000+0 0  9992",
+        "2 40003  10.0000  45.0000 6000000 120.0000  30.0000  1.00270000    12",
+        (
+            (0.0, (-3908.635579786, -29105.396115816, -3167.620339585)),
+            (360.0, (50157.215190843, -34792.143566207, -10620.591900083)),
+            (1440.0, (-3138.053160242, -29721.818498590, -3341.469673313)),
+            (-720.0, (65153.254340756, -5998.684734843, -8873.889192963)),
+            (10000.0, (-13068.505240716, -18046.712453215, -640.852992890)),
+        ),
+    ),
+}
+
+
+@pytest.mark.parametrize("description", sorted(CASES))
+def test_deep_space_orbit_in_a_gap_of_the_verification_set(description):
+    """The propagated states match the reference implementation."""
+    line1, line2, expected_states = CASES[description]
+    orbital = Orbital("unknown", line1=line1, line2=line2)
+
+    for delay, expected_position in expected_states:
+        utc_time = np.timedelta64(round(delay * 60 * 1e6), "us") + orbital.tle.epoch
+        position, _ = orbital.get_position(utc_time, normalize=False)
+
+        np.testing.assert_allclose(position, expected_position, rtol=0,
+                                   atol=POSITION_TOLERANCE,
+                                   err_msg=f"{description} at {delay} min")

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -422,3 +422,16 @@ def test_get_last_an_time_wrong_input(dtime):
     expected = "UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!"
     with pytest.raises(ValueError, match=expected):
         _ = orb.get_last_an_time(dtime)
+
+
+def test_deep_space_rejects_several_times_at_once():
+    """Propagating a deep-space satellite to many times at once is not supported yet."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("MOLNIYA 2-14",
+                  line1="1 08195U 75081A   06176.33215444  .00000099  00000-0  11873-3 0   813",
+                  line2="2 08195  64.1586 279.0717 6877146 264.7651  20.2257  2.00491383225656")
+
+    times = orb.tle.epoch + np.array([0, 120], dtype="timedelta64[m]")
+
+    with pytest.raises(NotImplementedError, match="one time at a time"):
+        orb.get_position(times)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -437,17 +437,8 @@ def test_resonant_deep_space_propagates_several_times_like_one_at_a_time():
     together = orb.get_position(times, normalize=False)
     separately = [orb.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
-    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
-
-
-# Solving Kepler's equation stops when every time in the array has converged,
-# so a time asked for alongside others takes a few more turns of an almost
-# stationary loop than it would alone, and its last bits differ. See the same
-# note in test_aiaa.py.
-AT_ONCE_TOLERANCE = 1e-6  # km
+    np.testing.assert_array_equal(together[0], np.array([p for p, _ in separately]).T)
+    np.testing.assert_array_equal(together[1], np.array([v for _, v in separately]).T)
 
 
 def _deep_space_orbital(satellite, line1, line2):
@@ -468,10 +459,8 @@ def test_deep_space_propagates_several_times_like_one_at_a_time():
     together = orb.get_position(times, normalize=False)
     separately = [orb.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
-    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_array_equal(together[0], np.array([p for p, _ in separately]).T)
+    np.testing.assert_array_equal(together[1], np.array([v for _, v in separately]).T)
 
 
 def test_resonant_deep_space_propagates_backwards_and_forwards_at_once():
@@ -482,10 +471,8 @@ def test_resonant_deep_space_propagates_backwards_and_forwards_at_once():
     together = orb.get_position(times, normalize=False)
     separately = [orb.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
-    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
-                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_array_equal(together[0], np.array([p for p, _ in separately]).T)
+    np.testing.assert_array_equal(together[1], np.array([v for _, v in separately]).T)
 
 
 def test_resonant_deep_space_does_not_care_what_order_the_times_come_in():

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -424,9 +424,25 @@ def test_get_last_an_time_wrong_input(dtime):
         _ = orb.get_last_an_time(dtime)
 
 
+# The propagator gives the same answer either way; numpy may evaluate a sine
+# over an array with different instructions than over a single number, and the
+# two can differ in the last bit. See the same note in test_aiaa.py.
+AT_ONCE_TOLERANCE = 1e-9  # km
+
+
+def _deep_space_orbital(satellite, line1, line2):
+    from pyorbital.orbital import Orbital
+    return Orbital(satellite, line1=line1, line2=line2)
+
+
 RESONANT_DEEP_SPACE = (
     "1 08195U 75081A   06176.33215444  .00000099  00000-0  11873-3 0   813",
     "2 08195  64.1586 279.0717 6877146 264.7651  20.2257  2.00491383225656")
+
+
+NON_RESONANT_DEEP_SPACE = (
+    "1 23177U 94040C   06175.45752052  .00000386  00000-0  76590-3 0    95",
+    "2 23177   7.0496 179.8238 7258491 296.0482   8.3061  2.25906668 97438")
 
 
 def test_resonant_deep_space_propagates_several_times_like_one_at_a_time():
@@ -437,18 +453,10 @@ def test_resonant_deep_space_propagates_several_times_like_one_at_a_time():
     together = orb.get_position(times, normalize=False)
     separately = [orb.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_array_equal(together[0], np.array([p for p, _ in separately]).T)
-    np.testing.assert_array_equal(together[1], np.array([v for _, v in separately]).T)
-
-
-def _deep_space_orbital(satellite, line1, line2):
-    from pyorbital.orbital import Orbital
-    return Orbital(satellite, line1=line1, line2=line2)
-
-
-NON_RESONANT_DEEP_SPACE = (
-    "1 23177U 94040C   06175.45752052  .00000386  00000-0  76590-3 0    95",
-    "2 23177   7.0496 179.8238 7258491 296.0482   8.3061  2.25906668 97438")
+    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
 
 
 def test_deep_space_propagates_several_times_like_one_at_a_time():
@@ -459,8 +467,10 @@ def test_deep_space_propagates_several_times_like_one_at_a_time():
     together = orb.get_position(times, normalize=False)
     separately = [orb.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_array_equal(together[0], np.array([p for p, _ in separately]).T)
-    np.testing.assert_array_equal(together[1], np.array([v for _, v in separately]).T)
+    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
 
 
 def test_resonant_deep_space_propagates_backwards_and_forwards_at_once():
@@ -471,8 +481,10 @@ def test_resonant_deep_space_propagates_backwards_and_forwards_at_once():
     together = orb.get_position(times, normalize=False)
     separately = [orb.get_position(time, normalize=False) for time in times]
 
-    np.testing.assert_array_equal(together[0], np.array([p for p, _ in separately]).T)
-    np.testing.assert_array_equal(together[1], np.array([v for _, v in separately]).T)
+    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
 
 
 def test_resonant_deep_space_does_not_care_what_order_the_times_come_in():

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -424,14 +424,85 @@ def test_get_last_an_time_wrong_input(dtime):
         _ = orb.get_last_an_time(dtime)
 
 
-def test_deep_space_rejects_several_times_at_once():
-    """Propagating a deep-space satellite to many times at once is not supported yet."""
+RESONANT_DEEP_SPACE = (
+    "1 08195U 75081A   06176.33215444  .00000099  00000-0  11873-3 0   813",
+    "2 08195  64.1586 279.0717 6877146 264.7651  20.2257  2.00491383225656")
+
+
+def test_resonant_deep_space_propagates_several_times_like_one_at_a_time():
+    """A resonant orbit gives the same answer for many times at once as for each alone."""
+    orb = _deep_space_orbital("MOLNIYA 2-14", *RESONANT_DEEP_SPACE)
+    times = orb.tle.epoch + np.array([0, 720, 1440, 2000], dtype="timedelta64[m]")
+
+    together = orb.get_position(times, normalize=False)
+    separately = [orb.get_position(time, normalize=False) for time in times]
+
+    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+
+
+# Solving Kepler's equation stops when every time in the array has converged,
+# so a time asked for alongside others takes a few more turns of an almost
+# stationary loop than it would alone, and its last bits differ. See the same
+# note in test_aiaa.py.
+AT_ONCE_TOLERANCE = 1e-6  # km
+
+
+def _deep_space_orbital(satellite, line1, line2):
     from pyorbital.orbital import Orbital
-    orb = Orbital("MOLNIYA 2-14",
-                  line1="1 08195U 75081A   06176.33215444  .00000099  00000-0  11873-3 0   813",
-                  line2="2 08195  64.1586 279.0717 6877146 264.7651  20.2257  2.00491383225656")
+    return Orbital(satellite, line1=line1, line2=line2)
 
-    times = orb.tle.epoch + np.array([0, 120], dtype="timedelta64[m]")
 
-    with pytest.raises(NotImplementedError, match="one time at a time"):
-        orb.get_position(times)
+NON_RESONANT_DEEP_SPACE = (
+    "1 23177U 94040C   06175.45752052  .00000386  00000-0  76590-3 0    95",
+    "2 23177   7.0496 179.8238 7258491 296.0482   8.3061  2.25906668 97438")
+
+
+def test_deep_space_propagates_several_times_like_one_at_a_time():
+    """Propagating to many times at once agrees with propagating to each in turn."""
+    orb = _deep_space_orbital("ARIANE", *NON_RESONANT_DEEP_SPACE)
+    times = orb.tle.epoch + np.array([0, 120, 360, 720], dtype="timedelta64[m]")
+
+    together = orb.get_position(times, normalize=False)
+    separately = [orb.get_position(time, normalize=False) for time in times]
+
+    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+
+
+def test_resonant_deep_space_propagates_backwards_and_forwards_at_once():
+    """Times before and after the epoch may be mixed in one array."""
+    orb = _deep_space_orbital("MOLNIYA 2-14", *RESONANT_DEEP_SPACE)
+    times = orb.tle.epoch + np.array([-1440, -720, 0, 720, 1440], dtype="timedelta64[m]")
+
+    together = orb.get_position(times, normalize=False)
+    separately = [orb.get_position(time, normalize=False) for time in times]
+
+    np.testing.assert_allclose(together[0], np.array([p for p, _ in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+    np.testing.assert_allclose(together[1], np.array([v for _, v in separately]).T,
+                               rtol=0, atol=AT_ONCE_TOLERANCE)
+
+
+def test_resonant_deep_space_does_not_care_what_order_the_times_come_in():
+    """The answer for a time does not depend on which other times are asked for.
+
+    The resonance is followed step by step from the epoch, which would invite
+    carrying the integration between calls; doing so would make the answer
+    depend on the order of the calls, and it must not.
+    """
+    orb = _deep_space_orbital("MOLNIYA 2-14", *RESONANT_DEEP_SPACE)
+    offsets = np.array([0, 2000, -1440, 720, 5000, -300], dtype="timedelta64[m]")
+    times = orb.tle.epoch + offsets
+
+    in_order = orb.get_position(times, normalize=False)
+    shuffled = np.array([3, 0, 5, 1, 4, 2])
+    out_of_order = orb.get_position(times[shuffled], normalize=False)
+    again = orb.get_position(times, normalize=False)
+
+    np.testing.assert_array_equal(out_of_order[0], in_order[0][:, shuffled])
+    np.testing.assert_array_equal(again[0], in_order[0])


### PR DESCRIPTION
# What this does

pyorbital refused any satellite whose orbit takes 225 minutes or more, and also refused near-earth satellites with a low enough perigee to need the simplified drag equations. Between them that was 26 of the 29 satellites in the AIAA verification set. This adds the deep-space model from AIAA 2006-6753 in a new module, pyorbital/_sgdp4_deep.py, hooked into the existing propagator: the geometry of the Sun and Moon at the epoch, the slow drift they impose, the periodic wobble they impose, and — for orbits that circle once or twice while the Earth turns once — the beat against the Earth's own equatorial bulges, integrated forward in twelve-hour steps.

All 29 verification satellites now propagate, with no skips.

# Two bugs found on the way

The mean motion constant was rounded. XKE was hardcoded as 0.743669161e-1, the nine-digit decimal printed in Spacetrack Report #3. Its relative error of 4.5e-10 lands in the semi-major axis, shifts the computed perigee by 1.9e-6 km, and because the atmospheric drag fit takes (120 - sfour) — a difference of nearly equal altitudes — to the fourth power, it comes out amplified 370× for low-perigee satellites. It cost half a metre of along-track position over a day and kept three satellites from being propagated at all. XKE and QOMS2T are now computed from the defining WGS-72 parameters. This improved every near-earth satellite by roughly 100×, including ones that were already passing.

The drag correction was applied where it shouldn't be. The mean-anomaly and argument-of-perigee correction was applied unconditionally; Vallado applies it only when the full drag expansion is in use. Deep-space and low-perigee satellites share the simplified equations, so that condition is now named rather than tested in four places.

# Also

- Deep-space satellites propagate to an array of times, ~150× faster than looping.
- Propagating to a set of times now gives bit-for-bit what propagating to each gives. Kepler's equation was iterated until every time in the array had converged, so the ones that converged first kept being nudged and their last bits depended on what else was in the array.
- The resonance integrator restarts from the epoch on every call rather than carrying state, so an answer never depends on what was asked before. Cost is linear in distance from epoch; an array shares one march.
- Removed a wrapper class of 40 properties that only forwarded to the object beside it.
- Verification harness rewritten as one test per satellite, reaching the propagator through the public API only, with a meta-test that makes a silently-skipped satellite impossible.

# Accuracy

All 29 satellites match aiaa_results within main's tolerances (5e-6 km, 5e-9 km/s). Worst position error is 4.475e-06 km on satellite 23333 (WIND, eccentricity 0.973) — 89% of the budget. Worst velocity error is 45% of budget. Beyond the verification set, ~24,000 propagated states across ~2,270 synthetic orbits spanning inclination, eccentricity and mean motion agree with the reference implementation to under 1e-5 km for every orbit whose perigee is above ground.

# Known follow-ups

1. Satellite 23333 uses 89% of the position tolerance. It's newly under test (previously skipped as deep-space), and the reference implementation matches the file to 4.6e-9 km where we're at 4.5e-6. A real difference specific to extreme eccentricity, not yet explained — the Kepler stopping criterion accounts for only a small part of it. Worth a look before anyone tightens tolerances further.
2. Mutation testing showed the verification set doesn't pin three branches (an eccentricity fit boundary, a resonance band edge, and the geosynchronous eccentricity terms). test_deep_space_branches.py adds three orbits that do.

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
