### PR TITLE
Propagate orbits of no eccentricity at all

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -1272,7 +1272,9 @@ class _Keplerians:
 
 
 def _check_orbital_elements(orbit_elements):
-    if not (0 < orbit_elements.eccentricity < ECC_LIMIT_HIGH):
+    # An orbit of no eccentricity at all is a circle, which is a perfectly good
+    # orbit and one this model propagates as well as any other.
+    if not (0 <= orbit_elements.eccentricity < ECC_LIMIT_HIGH):
         raise OrbitalError("Eccentricity out of range: %e" % orbit_elements.eccentricity)
     if not ((0.0035 * 2 * np.pi / XMNPDA) < orbit_elements.original_mean_motion < (18 * 2 * np.pi / XMNPDA)):
         raise OrbitalError("Mean motion out of range: %e" % orbit_elements.original_mean_motion)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -422,3 +422,23 @@ def test_get_last_an_time_wrong_input(dtime):
     expected = "UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!"
     with pytest.raises(ValueError, match=expected):
         _ = orb.get_last_an_time(dtime)
+
+
+def test_a_circular_orbit_can_be_propagated():
+    """An orbit of no eccentricity at all is a real orbit, not a bad element set.
+
+    Its distance from the centre of the Earth stays nearly constant, varying
+    only by the short period wobble the equatorial bulge imposes.
+    """
+    from pyorbital.orbital import Orbital
+    orb = Orbital(
+        "CIRCULAR",
+        line1="1 43013U 06001A   24176.00000000  .00000000  00000+0  00000+0 0  9996",
+        line2="2 43013  98.7060 114.5340 0000000 139.3958 190.7541 14.19599847    14")
+
+    times = orb.tle.epoch + np.arange(0, 101) * np.timedelta64(60, "s")
+    position, _ = orb.get_position(times, normalize=False)
+
+    radius = np.sqrt((np.asarray(position) ** 2).sum(axis=0))
+    assert radius.max() - radius.min() < 20.0
+    np.testing.assert_allclose(radius.mean(), 7205.0, atol=20.0)


### PR DESCRIPTION
A circle is a perfectly good orbit, and the model propagates one as well as it does any other, but the element set was turned away before it got that far: the eccentricity had to be greater than zero, not merely not less than it.

Letting it through, a circular orbit agrees with the reference implementation to a ten-thousandth of a millimetre over two hundred and ten states, spread across inclinations from a thousandth of a degree to retrograde and periods from a low orbit to a geosynchronous one. The reference implementation never objected to these element sets in the first place.

The test propagates such an orbit for one revolution and checks that its distance from the centre of the Earth stays put, wandering only the fifteen kilometres the equatorial bulge accounts for.

<!-- Please make the PR against the `main` branch. -->

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
