### PR TITLE
Add the METimage instrument definition

### DIFF
--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -786,6 +786,84 @@ def viirs_edge_geom(scans_nb):
 
 ################################################################
 #
+#   METimage (VII)
+#
+################################################################
+
+# METimage (also known as VII, the VIS/IR Imager) on Metop-SG-A.
+#
+# Sources:
+#   EPS-SG VII Level 1B Product Format Specification,
+#   EUM/LEO-EPSSG/SPE/14/777138 v5A (20 September 2024), Table 10:
+#   https://user.eumetsat.int/s3/eup-strapi-media/EPS_SG_VII_Level_1_B_Product_Format_Specification_654c0b397a.pdf
+#     num_pixels = 3144 (across-track samples per scan)
+#     num_pixels_alt = 24 (along-track samples per scan)
+#     Pixel 1 is the furthest point from nadir on the left side with respect
+#     to the spacecraft motion.
+#
+#   C. Cao, "Introducing METImage: EUMETSAT's next generation polar imager on
+#   METOP-SG", NOAA STAR seminar, 21 August 2019:
+#   https://www.star.nesdis.noaa.gov/star/documents/seminardocs/2019/20190821_Cao.pdf
+#     Whisk-broom scanner, 24 detector lines per scan, 1.729 s per scan
+#     rotation at constant scan angle, IFOV 0.6 mrad, and a scan mirror
+#     covering an extended Earth view of 108 degrees per revolution.
+#
+#   R. Bruens et al., "METimage - an innovative imaging radiometer for
+#   Post-EPS", EUMETSAT Meteorological Satellite Conference:
+#   https://www-cdn.eumetsat.int/files/2020-04/pdf_conf_p50_s1_02_bruens_p.pdf
+#     Describes the rotating telescope scanner: the telescope itself rotates
+#     and a half-angle derotator mirror produces a standing image, so there is
+#     no image rotation across the swath.
+#
+# Consistency of the numbers above: 108 deg spread over 3144 samples gives
+# 0.6 mrad per sample, so the across-track sampling is contiguous, the step
+# being exactly the IFOV.  The pixels are square (0.5 km at nadir from the
+# 830 km orbit is the same 0.6 mrad), so the along-track spacing of the
+# detector rows is that same sampling step.
+_METIMAGE_EARTH_VIEW = 108.0   # degrees of Earth view per telescope revolution
+_METIMAGE_SCAN_RATE = 1.729    # seconds per telescope revolution
+_METIMAGE_PIXELS = 3144
+_METIMAGE_LINES_PER_SCAN = 24
+_METIMAGE_SAMPLING_STEP = np.deg2rad(_METIMAGE_EARTH_VIEW) / _METIMAGE_PIXELS
+# The 108 degrees are the extent of the Earth view, that is of the 3144 pixels
+# edge to edge.  The scan angle wanted here is the one of the outermost pixel
+# centres, half a pixel further in on either side.
+_METIMAGE_SCAN_ANGLE = np.rad2deg(_METIMAGE_SAMPLING_STEP * (_METIMAGE_PIXELS - 1) / 2)
+# The scan angle rate is constant, so the Earth view takes up the same
+# fraction of the revolution time as it does of the full 360 degrees.
+_METIMAGE_SWEEP_TIME = _METIMAGE_SCAN_RATE * _METIMAGE_EARTH_VIEW / 360.0
+
+METIMAGE_SCAN = MultiLineWhiskbroomScan(
+    pixels_per_scan=_METIMAGE_PIXELS,
+    scan_angle=_METIMAGE_SCAN_ANGLE,
+    scan_rate=_METIMAGE_SCAN_RATE,
+    pixel_dwell_time=_METIMAGE_SWEEP_TIME / _METIMAGE_PIXELS,
+    lines_per_scan=_METIMAGE_LINES_PER_SCAN,
+    along_track_step=_METIMAGE_SAMPLING_STEP,
+)
+
+
+def metimage(scans_nb, scan_points=None):
+    """Describe the METimage (VII) instrument geometry.
+
+    METimage is a whisk-broom scanner recording 24 lines simultaneously for
+    each sweep of the rotating telescope, so the scan angles (and times) are
+    two-dimensional arrays, contrary to AVHRR for example.
+
+    Args:
+        scans_nb: Number of scans (each scan yields 24 lines).
+        scan_points: Across track pixel positions, all 3144 by default.
+    """
+    return METIMAGE_SCAN.scan_geometry(scans_nb, scan_points)
+
+
+def metimage_edge_geom(scans_nb):
+    """Definition of the METimage scan edges."""
+    return metimage(scans_nb, np.array([0, _METIMAGE_PIXELS - 1]))
+
+
+################################################################
+#
 #   AMSU-A
 #
 ################################################################

--- a/pyorbital/tests/test_geoloc.py
+++ b/pyorbital/tests/test_geoloc.py
@@ -1650,3 +1650,93 @@ def test_geocentric_nadir_stays_geocentric_when_velocity_is_not_perpendicular():
     # and the frame is still orthonormal, which the rotations require
     assert abs(float(np.sum(nadir * along_track))) < 1e-12
     assert abs(float(np.sum(nadir * cross_track))) < 1e-12
+
+
+def test_metimage_scan_geometry_shape():
+    """Test that metimage produces 24 lines per scan over the full 3144-pixel swath."""
+    from pyorbital.geoloc_instrument_definitions import metimage
+
+    geom = metimage(3)
+
+    assert geom.fovs.shape == (2, 3 * 24, 3144)
+    assert geom.lines_per_scan == 24
+
+
+def test_metimage_swath_spans_the_earth_view():
+    """Check that the METimage swath edges are at the documented +-54 degrees."""
+    from pyorbital.geoloc_instrument_definitions import metimage_edge_geom
+
+    geom = metimage_edge_geom(1)
+
+    cross_track = np.rad2deg(geom.fovs[0, 0, :])
+    # pixel 1 is the furthest point from nadir on the left of the ground track
+    assert cross_track[0] > 0
+    np.testing.assert_allclose(cross_track, [53.9828, -53.9828], atol=1e-4)
+    # the 108 degree Earth view is the edge-to-edge extent of the 3144 pixels
+    edge_to_edge = cross_track[0] - cross_track[-1] + 108.0 / 3144
+    np.testing.assert_allclose(edge_to_edge, 108.0, atol=1e-9)
+
+
+def test_metimage_sampling_step_matches_the_ifov():
+    """The 3144 samples over 108 degrees must come out at the documented 0.6 mrad IFOV."""
+    from pyorbital.geoloc_instrument_definitions import METIMAGE_SCAN
+
+    cross_track = METIMAGE_SCAN.cross_track_angles()
+    steps = np.diff(cross_track)
+
+    np.testing.assert_allclose(np.abs(steps), 6.0e-4, rtol=1e-2)
+    # the pixels are square, so the detector rows are spaced by the same angle
+    np.testing.assert_allclose(METIMAGE_SCAN.along_track_step, np.abs(steps), rtol=1e-9)
+
+
+def test_metimage_scan_times_cover_the_earth_view_fraction():
+    """The Earth view takes 108/360 of the 1.729 s revolution at constant scan rate."""
+    from pyorbital.geoloc_instrument_definitions import METIMAGE_SCAN, metimage
+
+    geom = metimage(2)
+    first_scan = geom._times[:24, :]
+
+    sweep = (first_scan[0, -1] - first_scan[0, 0]) / np.timedelta64(1, "s")
+    np.testing.assert_allclose(sweep, 1.729 * 108.0 / 360.0, rtol=1e-3)
+    # consecutive scans are one full revolution apart
+    second_scan_start = geom._times[24, 0]
+    np.testing.assert_allclose(
+        (second_scan_start - first_scan[0, 0]) / np.timedelta64(1, "s"),
+        METIMAGE_SCAN.scan_rate, rtol=1e-9)
+
+
+@pytest.mark.parametrize("kwargs", NADIR_CONVENTION_CASES)
+def test_metimage_geolocates_a_swath(kwargs):
+    """Check that a METimage swath lands on the ground with the expected width."""
+    from pyorbital.geoloc import compute_pixels, get_lonlatalt
+    from pyorbital.geoloc_instrument_definitions import metimage_edge_geom
+
+    tle1 = "1 33591U 09005A   21355.91138073  .00000074  00000+0  65091-4 0  9998"
+    tle2 = "2 33591  99.1688  21.1338 0013414 329.8936  30.1462 14.12516400663123"
+    t = dt.datetime(2021, 12, 21, 12, 0, 0)
+
+    sgeom = metimage_edge_geom(3)
+    s_times = sgeom.times(t)
+    with config.set(rotation_order="legacy"):
+        pixels = compute_pixels((tle1, tle2), sgeom, s_times, **kwargs)
+    lons, lats, alts = get_lonlatalt(pixels, s_times)
+
+    assert lons.shape == (3 * 24 * 2,)
+    assert np.all(np.isfinite(lons))
+    np.testing.assert_allclose(alts, 0.0, atol=1e-6)
+
+    # the swath edges of the first line, some 1400 km either side of the track
+    left, right = _earth_centred_vector(lons[0], lats[0]), _earth_centred_vector(lons[1], lats[1])
+    width = np.linalg.norm(left - right)
+    assert 2700 < width < 2900
+
+
+def _earth_centred_vector(lon, lat):
+    """Get the WGS84 cartesian position of a point on the ellipsoid, in km."""
+    lon, lat = np.deg2rad(lon), np.deg2rad(lat)
+    a, f = 6378.137, 1 / 298.257223563
+    e2 = f * (2 - f)
+    prime_vertical = a / np.sqrt(1 - e2 * np.sin(lat) ** 2)
+    return np.array([prime_vertical * np.cos(lat) * np.cos(lon),
+                     prime_vertical * np.cos(lat) * np.sin(lon),
+                     prime_vertical * (1 - e2) * np.sin(lat)])


### PR DESCRIPTION
METimage (VII) on Metop-SG-A is a whisk-broom scanner recording 24 lines per sweep of its rotating telescope, so it fits MultiLineWhiskbroomScan directly.  The geometry comes from the EPS-SG VII L1B product format specification (3144 across-track samples, 24 along-track samples per scan) and from the instrument description (1.729 s per revolution at constant scan angle, 0.6 mrad IFOV, 108 degrees of Earth view).

Without this, trollsched fails with an AttributeError when computing a METimage swath boundary, as it looks the instrument up by name in pyorbital.geoloc_instrument_definitions.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

