### PR TITLE
Add get_last_dn_time, find_aos and find_aol

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -255,16 +255,15 @@ class Orbital(object):
         """
         passes = self.get_next_passes(utc_time, _HORIZON_SEARCH_HOURS, lon, lat, alt, horizon=horizon)
         if not passes:
-            raise ValueError(f"{self.satellite_name} does not rise above {horizon} degrees "
-                             f"for this observer within {_HORIZON_SEARCH_HOURS} hours of {utc_time}")
+            raise self._no_crossing_found(horizon, utc_time, rising=True)
         rise_time, _, _ = passes[0]
         return rise_time
 
     def find_aol(self, utc_time, lon, lat, alt=0, horizon=0):
         """Find when the satellite next sets below the observer's horizon.
 
-        The search runs over the next 24 hours, and returns None if the
-        satellite does not set in that time. Unlike find_aos, a pass already
+        The search runs over the next 24 hours, and raises a ValueError if no
+        setting is found in that time. Unlike find_aos, a pass already
         under way when *utc_time* falls inside it does count: the answer is
         then the end of that pass, so the two need not describe the same one.
 
@@ -279,6 +278,13 @@ class Orbital(object):
                 minutes = _get_root(elevation_at, crossing, crossing + 1.0,
                                     tol=_CROSSING_TOLERANCE_SECONDS / 60.0)
                 return utc_time + dt.timedelta(minutes=minutes)
+        raise self._no_crossing_found(horizon, utc_time, rising=False)
+
+    def _no_crossing_found(self, horizon, utc_time, rising):
+        """Explain that the horizon crossing asked for is not in the searched window."""
+        crossing = "rise above" if rising else "set below"
+        return ValueError(f"{self.satellite_name} does not {crossing} {horizon} degrees "
+                          f"for this observer within {_HORIZON_SEARCH_HOURS} hours of {utc_time}")
 
     def _scan_elevation(self, utc_time, hours, lon, lat, alt, horizon):
         """Sample the elevation above *horizon* once a minute, and find the horizon crossings.

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -52,6 +52,11 @@ SECDAY = 8.6400E4
 F = 1 / 298.257223563  # Earth flattening WGS-84
 A = 6378.137  # WGS84 Equatorial radius
 
+# How far back to step when hunting for the equator crossing before a given time,
+# and how close to the equatorial plane counts as having found it.
+_NODE_SEARCH_STEP = np.timedelta64(10, "m")
+_NODE_TOLERANCE_KM = 1
+
 
 SGDP4_ZERO_ECC = 0
 SGDP4_DEEP_NORM = 1
@@ -146,37 +151,52 @@ class Orbital(object):
 
     def get_last_an_time(self, utc_time):
         """Calculate time of last ascending node relative to the specified time."""
-        # Propagate backwards to ascending node
-        dt = np.timedelta64(10, "m")
+        return self._get_last_node_time(utc_time, ascending=True)
 
-        t_old = np.datetime64(_get_tz_unaware_utctime(utc_time))
-        t_new = t_old - dt
-        pos0, vel0 = self.get_position(t_old, normalize=False)
-        pos1, vel1 = self.get_position(t_new, normalize=False)
-        while not (pos0[2] > 0 and pos1[2] < 0):
-            pos0 = pos1
-            t_old = t_new
-            t_new = t_old - dt
-            pos1, vel1 = self.get_position(t_new, normalize=False)
+    def get_last_dn_time(self, utc_time):
+        """Calculate time of last descending node relative to the specified time."""
+        return self._get_last_node_time(utc_time, ascending=False)
 
-        # Return if z within 1 km of an
-        if np.abs(pos0[2]) < 1:
-            return t_old
-        elif np.abs(pos1[2]) < 1:
-            return t_new
+    def _get_last_node_time(self, utc_time, ascending):
+        """Calculate time of the last equator crossing before the specified time.
 
-        # Bisect to z within 1 km
-        while np.abs(pos1[2]) > 1:
-            # pos0, vel0 = pos1, vel1
-            dt = (t_old - t_new) / 2
-            t_mid = t_old - dt
-            pos1, vel1 = self.get_position(t_mid, normalize=False)
-            if pos1[2] > 0:
-                t_old = t_mid
+        The satellite crosses an ascending node heading north and a descending
+        node heading south. Multiplying its z coordinate by *heading* makes the
+        two cases one: the product is positive after the node and negative
+        before it, whichever node is asked for.
+        """
+        heading = 1 if ascending else -1
+
+        later = np.datetime64(_get_tz_unaware_utctime(utc_time))
+        earlier = later - _NODE_SEARCH_STEP
+        z_later = self._z_position(later)
+        z_earlier = self._z_position(earlier)
+
+        while not (z_later * heading > 0 and z_earlier * heading < 0):
+            z_later = z_earlier
+            later = earlier
+            earlier = later - _NODE_SEARCH_STEP
+            z_earlier = self._z_position(earlier)
+
+        if np.abs(z_later) < _NODE_TOLERANCE_KM:
+            return later
+        if np.abs(z_earlier) < _NODE_TOLERANCE_KM:
+            return earlier
+
+        while np.abs(z_earlier) > _NODE_TOLERANCE_KM:
+            middle = later - (later - earlier) / 2
+            z_earlier = self._z_position(middle)
+            if z_earlier * heading > 0:
+                later = middle
             else:
-                t_new = t_mid
+                earlier = middle
 
-        return t_mid
+        return middle
+
+    def _z_position(self, utc_time):
+        """Get the satellite's distance north of the equatorial plane, in km."""
+        position, _ = self.get_position(utc_time, normalize=False)
+        return position[2]
 
     def get_position(self, utc_time, normalize=True):
         """Get the cartesian position and velocity from the satellite."""

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -189,15 +189,15 @@ class Orbital(object):
         if np.abs(z_earlier) < _NODE_TOLERANCE_KM:
             return earlier
 
-        while np.abs(z_earlier) > _NODE_TOLERANCE_KM:
+        while True:
             middle = later - (later - earlier) / 2
-            z_earlier = self._z_position(middle)
-            if z_earlier * heading > 0:
+            z_middle = self._z_position(middle)
+            if np.abs(z_middle) <= _NODE_TOLERANCE_KM:
+                return middle
+            if z_middle * heading > 0:
                 later = middle
             else:
                 earlier = middle
-
-        return middle
 
     def _z_position(self, utc_time):
         """Get the satellite's distance north of the equatorial plane, in km."""

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -57,6 +57,9 @@ A = 6378.137  # WGS84 Equatorial radius
 _NODE_SEARCH_STEP = np.timedelta64(10, "m")
 _NODE_TOLERANCE_KM = 1
 
+# How far ahead to look for the next horizon crossing.
+_HORIZON_SEARCH_HOURS = 24
+
 
 SGDP4_ZERO_ECC = 0
 SGDP4_DEEP_NORM = 1
@@ -236,9 +239,20 @@ class Orbital(object):
         alt *= A
         return np.rad2deg(lon), np.rad2deg(lat), alt
 
-    def find_aos(self, utc_time, lon, lat):
-        """Find AOS."""
-        pass
+    def find_aos(self, utc_time, lon, lat, alt=0, horizon=0):
+        """Find when the satellite next rises above the observer's horizon.
+
+        The search runs over the next 24 hours, and raises an IndexError if
+        nothing rises in that time. A pass already under way when *utc_time*
+        falls inside it is not reported; the answer is the rise of the pass
+        after it.
+
+        Elevation is sampled once a minute to bracket the crossing, so a pass
+        that begins and ends between two samples is not seen.
+        """
+        passes = self.get_next_passes(utc_time, _HORIZON_SEARCH_HOURS, lon, lat, alt, horizon=horizon)
+        rise_time, _, _ = passes[0]
+        return rise_time
 
     def find_aol(self, utc_time, lon, lat):
         """Find AOL."""

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -60,6 +60,9 @@ _NODE_TOLERANCE_KM = 1
 # How far ahead to look for the next horizon crossing.
 _HORIZON_SEARCH_HOURS = 24
 
+# Precision of a computed horizon crossing, in seconds.
+_CROSSING_TOLERANCE_SECONDS = 0.001
+
 
 SGDP4_ZERO_ECC = 0
 SGDP4_DEEP_NORM = 1
@@ -254,9 +257,36 @@ class Orbital(object):
         rise_time, _, _ = passes[0]
         return rise_time
 
-    def find_aol(self, utc_time, lon, lat):
-        """Find AOL."""
-        pass
+    def find_aol(self, utc_time, lon, lat, alt=0, horizon=0):
+        """Find when the satellite next sets below the observer's horizon.
+
+        The search runs over the next 24 hours, and returns None if the
+        satellite does not set in that time. Unlike find_aos, a pass already
+        under way when *utc_time* falls inside it does count: the answer is
+        then the end of that pass, so the two need not describe the same one.
+
+        Elevation is sampled once a minute to bracket the crossing, so a pass
+        that begins and ends between two samples is not seen.
+        """
+        elevation, crossings = self._scan_elevation(utc_time, _HORIZON_SEARCH_HOURS,
+                                                    lon, lat, alt, horizon)
+        elevation_at = partial(self._elevation, utc_time, lon, lat, alt, horizon)
+        for crossing in crossings:
+            if elevation[crossing] > 0:
+                minutes = _get_root(elevation_at, crossing, crossing + 1.0,
+                                    tol=_CROSSING_TOLERANCE_SECONDS / 60.0)
+                return utc_time + dt.timedelta(minutes=minutes)
+
+    def _scan_elevation(self, utc_time, hours, lon, lat, alt, horizon):
+        """Sample the elevation above *horizon* once a minute, and find the horizon crossings.
+
+        Returns the samples and the indices preceding a crossing, so crossing
+        *i* lies between minute *i* and minute *i* + 1.
+        """
+        times = utc_time + np.array([dt.timedelta(minutes=minutes)
+                                     for minutes in range(hours * 60)])
+        elevation = self.get_observer_look(times, lon, lat, alt)[1] - horizon
+        return elevation, np.where(np.diff(np.sign(elevation)))[0]
 
     def get_observer_look(self, utc_time, lon, lat, alt):
         """Calculate observers look angle to a satellite.
@@ -348,7 +378,8 @@ class Orbital(object):
 
         return orbit
 
-    def get_next_passes(self, utc_time, length, lon, lat, alt, tol=0.001, horizon=0):
+    def get_next_passes(self, utc_time, length, lon, lat, alt,
+                        tol=_CROSSING_TOLERANCE_SECONDS, horizon=0):
         """Calculate passes for the next hours for a given start time and a given observer.
 
         Original by Martin.
@@ -364,11 +395,7 @@ class Orbital(object):
         :return: [(rise-time, fall-time, max-elevation-time), ...]
 
         """
-        # every minute
-        times = utc_time + np.array([dt.timedelta(minutes=minutes)
-                                     for minutes in range(length * 60)])
-        elev = self.get_observer_look(times, lon, lat, alt)[1] - horizon
-        zcs = np.where(np.diff(np.sign(elev)))[0]
+        elev, zcs = self._scan_elevation(utc_time, length, lon, lat, alt, horizon)
         res = []
         risetime = None
         risemins = None

--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -245,7 +245,7 @@ class Orbital(object):
     def find_aos(self, utc_time, lon, lat, alt=0, horizon=0):
         """Find when the satellite next rises above the observer's horizon.
 
-        The search runs over the next 24 hours, and raises an IndexError if
+        The search runs over the next 24 hours, and raises a ValueError if
         nothing rises in that time. A pass already under way when *utc_time*
         falls inside it is not reported; the answer is the rise of the pass
         after it.
@@ -254,6 +254,9 @@ class Orbital(object):
         that begins and ends between two samples is not seen.
         """
         passes = self.get_next_passes(utc_time, _HORIZON_SEARCH_HOURS, lon, lat, alt, horizon=horizon)
+        if not passes:
+            raise ValueError(f"{self.satellite_name} does not rise above {horizon} degrees "
+                             f"for this observer within {_HORIZON_SEARCH_HOURS} hours of {utc_time}")
         rise_time, _, _ = passes[0]
         return rise_time
 

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -477,3 +477,23 @@ def test_find_aos_is_the_satellite_rising_through_the_horizon():
     after = orb.get_observer_look(aos + a_moment, lon, lat, alt)[1]
     assert before < 0 < after
     assert aos > utc_time
+
+
+def test_find_aol_ends_the_pass_already_under_way():
+    """Loss of signal is the next time the satellite sets, which may end the current pass."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("NOAA-20",
+                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+    lon, lat, alt = 12.4143, 55.9065, 0.02
+
+    # The satellite is already up at 11:00, so it sets before it next rises.
+    utc_time = dt.datetime(2024, 6, 25, 11, 0)
+
+    aol = orb.find_aol(utc_time, lon, lat, alt)
+
+    a_moment = dt.timedelta(seconds=10)
+    before = orb.get_observer_look(aol - a_moment, lon, lat, alt)[1]
+    after = orb.get_observer_look(aol + a_moment, lon, lat, alt)[1]
+    assert before > 0 > after
+    assert utc_time < aol < orb.find_aos(utc_time, lon, lat, alt)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -390,21 +390,36 @@ class TestRegressions(unittest.TestCase):
         warnings.filterwarnings("default")
 
 
+@pytest.fixture
+def noaa_20():
+    """Orbital for NOAA-20, from a TLE of the 24th of June 2024."""
+    from pyorbital.orbital import Orbital
+    return Orbital("NOAA-20",
+                   line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+                   line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+
+
+# An observer in Copenhagen: longitude and latitude in degrees, altitude in km.
+OBSERVER = (12.4143, 55.9065, 0.02)
+
+
+def elevations_astride(orb, time, lon, lat, alt):
+    """Get the elevation of *orb* ten seconds before and ten seconds after *time*."""
+    a_moment = dt.timedelta(seconds=10)
+    return (orb.get_observer_look(time - a_moment, lon, lat, alt)[1],
+            orb.get_observer_look(time + a_moment, lon, lat, alt)[1])
+
+
 @pytest.mark.parametrize("dtime",
                          [dt.datetime(2024, 6, 25, 11, 0, 18),
                           dt.datetime(2024, 6, 25, 11, 5, 0, 0, dt.timezone.utc),
                           np.datetime64("2024-06-25T11:10:00.000000")
                           ]
                          )
-def test_get_last_an_time_scalar_input(dtime):
+def test_get_last_an_time_scalar_input(dtime, noaa_20):
     """Test getting the time of the last ascending node - input time is a scalar."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
-
     expected = np.datetime64("2024-06-25T10:44:18.234375")
-    result = orb.get_last_an_time(dtime)
+    result = noaa_20.get_last_an_time(dtime)
     assert abs(expected - result) < np.timedelta64(1, "s")
 
 
@@ -412,16 +427,11 @@ def test_get_last_an_time_scalar_input(dtime):
                          [dt.datetime(2024, 6, 25, 11, 5, 0, 0, dt.timezone(dt.timedelta(hours=1))),
                           ]
                          )
-def test_get_last_an_time_wrong_input(dtime):
+def test_get_last_an_time_wrong_input(dtime, noaa_20):
     """Test getting the time of the last ascending node - wrong input."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
-
     expected = "UTC time expected! Parsing a timezone aware datetime object requires it to be UTC!"
     with pytest.raises(ValueError, match=expected):
-        _ = orb.get_last_an_time(dtime)
+        _ = noaa_20.get_last_an_time(dtime)
 
 
 def test_a_circular_orbit_can_be_propagated():
@@ -444,79 +454,48 @@ def test_a_circular_orbit_can_be_propagated():
     np.testing.assert_allclose(radius.mean(), 7205.0, atol=20.0)
 
 
-def test_get_last_dn_time_is_a_descending_node():
+def test_get_last_dn_time_is_a_descending_node(noaa_20):
     """The last descending node is a time when the satellite crosses the equator southbound."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+    result = noaa_20.get_last_dn_time(dt.datetime(2024, 6, 25, 11, 0, 18))
 
-    result = orb.get_last_dn_time(dt.datetime(2024, 6, 25, 11, 0, 18))
-
-    (_, _, pos_z), (_, _, vel_z) = orb.get_position(result, normalize=False)
+    (_, _, pos_z), (_, _, vel_z) = noaa_20.get_position(result, normalize=False)
     assert abs(pos_z) < 1
     assert vel_z < 0
 
 
-def test_find_aos_is_the_satellite_rising_through_the_horizon():
+def test_find_aos_is_the_satellite_rising_through_the_horizon(noaa_20):
     """Acquisition of signal is when the satellite comes up over the horizon."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
-    lon, lat, alt = 12.4143, 55.9065, 0.02
-
     # 11:00 falls in the middle of a pass, so the answer is the pass after
     # this one, not the horizon crossing this one already made at 10:53.
     utc_time = dt.datetime(2024, 6, 25, 11, 0)
 
-    aos = orb.find_aos(utc_time, lon, lat, alt)
+    aos = noaa_20.find_aos(utc_time, *OBSERVER)
 
-    a_moment = dt.timedelta(seconds=10)
-    before = orb.get_observer_look(aos - a_moment, lon, lat, alt)[1]
-    after = orb.get_observer_look(aos + a_moment, lon, lat, alt)[1]
+    before, after = elevations_astride(noaa_20, aos, *OBSERVER)
     assert before < 0 < after
     assert aos > utc_time
 
 
-def test_find_aol_ends_the_pass_already_under_way():
+def test_find_aol_ends_the_pass_already_under_way(noaa_20):
     """Loss of signal is the next time the satellite sets, which may end the current pass."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
-    lon, lat, alt = 12.4143, 55.9065, 0.02
-
     # The satellite is already up at 11:00, so it sets before it next rises.
     utc_time = dt.datetime(2024, 6, 25, 11, 0)
 
-    aol = orb.find_aol(utc_time, lon, lat, alt)
+    aol = noaa_20.find_aol(utc_time, *OBSERVER)
 
-    a_moment = dt.timedelta(seconds=10)
-    before = orb.get_observer_look(aol - a_moment, lon, lat, alt)[1]
-    after = orb.get_observer_look(aol + a_moment, lon, lat, alt)[1]
+    before, after = elevations_astride(noaa_20, aol, *OBSERVER)
     assert before > 0 > after
-    assert utc_time < aol < orb.find_aos(utc_time, lon, lat, alt)
+    assert utc_time < aol < noaa_20.find_aos(utc_time, *OBSERVER)
 
 
-def test_find_aos_says_so_when_the_satellite_never_rises_that_far():
+def test_find_aos_says_so_when_the_satellite_never_rises_that_far(noaa_20):
     """A horizon the satellite never clears is reported, not left to an IndexError."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
-
     # The horizon asked for belongs in the message; its exact prose does not.
     with pytest.raises(ValueError, match="85"):
-        orb.find_aos(dt.datetime(2024, 6, 25, 11, 0), 12.4143, 55.9065, 0.02, horizon=85)
+        noaa_20.find_aos(dt.datetime(2024, 6, 25, 11, 0), *OBSERVER, horizon=85)
 
 
-def test_find_aol_says_so_when_the_satellite_never_sets_that_far():
+def test_find_aol_says_so_when_the_satellite_never_sets_that_far(noaa_20):
     """A horizon the satellite never sets below is reported, not returned as a silent None."""
-    from pyorbital.orbital import Orbital
-    orb = Orbital("NOAA-20",
-                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
-                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
-
     with pytest.raises(ValueError, match="85"):
-        orb.find_aol(dt.datetime(2024, 6, 25, 11, 0), 12.4143, 55.9065, 0.02, horizon=85)
+        noaa_20.find_aol(dt.datetime(2024, 6, 25, 11, 0), *OBSERVER, horizon=85)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -442,3 +442,17 @@ def test_a_circular_orbit_can_be_propagated():
     radius = np.sqrt((np.asarray(position) ** 2).sum(axis=0))
     assert radius.max() - radius.min() < 20.0
     np.testing.assert_allclose(radius.mean(), 7205.0, atol=20.0)
+
+
+def test_get_last_dn_time_is_a_descending_node():
+    """The last descending node is a time when the satellite crosses the equator southbound."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("NOAA-20",
+                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+
+    result = orb.get_last_dn_time(dt.datetime(2024, 6, 25, 11, 0, 18))
+
+    (_, _, pos_z), (_, _, vel_z) = orb.get_position(result, normalize=False)
+    assert abs(pos_z) < 1
+    assert vel_z < 0

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -497,3 +497,15 @@ def test_find_aol_ends_the_pass_already_under_way():
     after = orb.get_observer_look(aol + a_moment, lon, lat, alt)[1]
     assert before > 0 > after
     assert utc_time < aol < orb.find_aos(utc_time, lon, lat, alt)
+
+
+def test_find_aos_says_so_when_the_satellite_never_rises_that_far():
+    """A horizon the satellite never clears is reported, not left to an IndexError."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("NOAA-20",
+                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+
+    # The horizon asked for belongs in the message; its exact prose does not.
+    with pytest.raises(ValueError, match="85"):
+        orb.find_aos(dt.datetime(2024, 6, 25, 11, 0), 12.4143, 55.9065, 0.02, horizon=85)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -509,3 +509,14 @@ def test_find_aos_says_so_when_the_satellite_never_rises_that_far():
     # The horizon asked for belongs in the message; its exact prose does not.
     with pytest.raises(ValueError, match="85"):
         orb.find_aos(dt.datetime(2024, 6, 25, 11, 0), 12.4143, 55.9065, 0.02, horizon=85)
+
+
+def test_find_aol_says_so_when_the_satellite_never_sets_that_far():
+    """A horizon the satellite never sets below is reported, not returned as a silent None."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("NOAA-20",
+                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+
+    with pytest.raises(ValueError, match="85"):
+        orb.find_aol(dt.datetime(2024, 6, 25, 11, 0), 12.4143, 55.9065, 0.02, horizon=85)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -456,3 +456,24 @@ def test_get_last_dn_time_is_a_descending_node():
     (_, _, pos_z), (_, _, vel_z) = orb.get_position(result, normalize=False)
     assert abs(pos_z) < 1
     assert vel_z < 0
+
+
+def test_find_aos_is_the_satellite_rising_through_the_horizon():
+    """Acquisition of signal is when the satellite comes up over the horizon."""
+    from pyorbital.orbital import Orbital
+    orb = Orbital("NOAA-20",
+                  line1="1 43013U 17073A   24176.73674251  .00000000  00000+0  11066-3 0 00014",
+                  line2="2 43013  98.7060 114.5340 0001454 139.3958 190.7541 14.19599847341971")
+    lon, lat, alt = 12.4143, 55.9065, 0.02
+
+    # 11:00 falls in the middle of a pass, so the answer is the pass after
+    # this one, not the horizon crossing this one already made at 10:53.
+    utc_time = dt.datetime(2024, 6, 25, 11, 0)
+
+    aos = orb.find_aos(utc_time, lon, lat, alt)
+
+    a_moment = dt.timedelta(seconds=10)
+    before = orb.get_observer_look(aos - a_moment, lon, lat, alt)[1]
+    after = orb.get_observer_look(aos + a_moment, lon, lat, alt)[1]
+    assert before < 0 < after
+    assert aos > utc_time


### PR DESCRIPTION
Picks up the two features from #206, which the author closed and invited us to
salvage. Both are written fresh; none of that branch's code is carried over.

`get_last_dn_time` gives the last descending node. It shares the existing
ascending node search, which already knew how to walk back to an equator
crossing and bisect onto it — a descending node is the same search with the
satellite heading the other way, so the two now differ only by a sign.

`find_aos` and `find_aol` were stubs that did nothing. `find_aos` asks
`get_next_passes` and takes the rise time of the first pass. `find_aol` scans
for the setting itself, because it has to answer about a pass already under
way and `get_next_passes` discards those.

Two things worth knowing about the result:

- Called mid-pass, the two describe **different passes**. `find_aos` answers
  about the next pass, `find_aol` about the end of the current one. That is
  what you want when you ask "when do I lose this satellite?", but it means
  they don't pair up. Both docstrings say so.
- Elevation is sampled once a minute, so a pass that begins and ends between
  two samples is not seen. #206 sampled every five minutes and missed short
  passes outright; this makes that rarer, not impossible. Fixing it properly
  means a step derived from the pass duration, which is separate work.

Asking for a horizon the satellite never reaches used to give a bare
`IndexError` or a silent `None`. Both now say which satellite, which horizon
and which window came up empty.

 - [x] Closes #95
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented