### PR TITLE
Compute get_lonlatalt altitude on WGS84 consistently

### DIFF
--- a/pyorbital/orbital.py
+++ b/pyorbital/orbital.py
@@ -203,9 +203,18 @@ class Orbital(object):
         http://celestrak.com/columns/v02n03/
         """
         (pos_x, pos_y, pos_z), (vel_x, vel_y, vel_z) = self.get_position(
-            utc_time, normalize=True)
+            utc_time, normalize=False)
 
-        lon = ((np.arctan2(pos_y * XKMPER, pos_x * XKMPER) - astronomy.gmst(utc_time))
+        # The geodetic conversion below is written in WGS84 Earth radii, so the
+        # kilometer position is scaled by the WGS84 equatorial radius A. Scaling
+        # by XKMPER instead (the WGS72 radius SGP4 propagates with) and then
+        # multiplying the altitude by A inflates it by A / XKMPER - 1, about
+        # 2 m for a low orbit and 13 m at geostationary altitude.
+        pos_x = pos_x / A
+        pos_y = pos_y / A
+        pos_z = pos_z / A
+
+        lon = ((np.arctan2(pos_y, pos_x) - astronomy.gmst(utc_time))
                % (2 * np.pi))
 
         lon = np.where(lon > np.pi, lon - np.pi * 2, lon)

--- a/pyorbital/tests/test_orbital.py
+++ b/pyorbital/tests/test_orbital.py
@@ -38,10 +38,39 @@ class Test(unittest.TestCase):
         lon, lat, alt = sat.get_lonlatalt(d)
         expected_lon = -68.199894472013213
         expected_lat = 23.159747677881075
-        expected_alt = 392.01953430856935
+        expected_alt = 392.01741241831
         assert np.abs(lon - expected_lon) < eps_deg, "Calculation of sublon failed"
         assert np.abs(lat - expected_lat) < eps_deg, "Calculation of sublat failed"
-        assert np.abs(alt - expected_alt) < eps_deg, "Calculation of altitude failed"
+        assert np.abs(alt - expected_alt) < 1e-6, "Calculation of altitude failed"
+
+    def test_sublonlat_altitude_is_geodetic_on_wgs84(self):
+        """The altitude is the WGS84 ellipsoidal height of the kilometer position.
+
+        Converting the propagated position to geodetic coordinates entirely in
+        WGS84 (equatorial radius A, flattening F) must reproduce get_lonlatalt.
+        Scaling the position by the WGS72 radius XKMPER and the altitude by A
+        instead inflates the altitude by A / XKMPER - 1, about 2 m for this orbit.
+        """
+        sat = orbital.Orbital("ISS (ZARYA)",
+                              line1="1 25544U 98067A   03097.78853147  "
+                                    ".00021906  00000-0  28403-3 0  8652",
+                              line2="2 25544  51.6361  13.7980 0004256  "
+                                    "35.6671  59.2566 15.58778559250029")
+        times = [dt.datetime(2003, 3, 23, 0, 3, 22) + dt.timedelta(minutes=m) for m in range(0, 90, 10)]
+        for d in times:
+            _, _, alt = sat.get_lonlatalt(d)
+            (x, y, z), _ = sat.get_position(d, normalize=False)
+            r = np.hypot(x, y)
+            e2 = orbital.F * (2 - orbital.F)
+            phi = np.arctan2(z, r)
+            for _ in range(50):
+                n = orbital.A / np.sqrt(1 - e2 * np.sin(phi) ** 2)
+                phi = np.arctan2(z + n * e2 * np.sin(phi), r)
+            n = orbital.A / np.sqrt(1 - e2 * np.sin(phi) ** 2)
+            expected_alt = r / np.cos(phi) - n
+            assert abs(alt - expected_alt) < 1e-9, d
+            inflated = expected_alt + (orbital.A / orbital.XKMPER - 1) * np.hypot(r, z)
+            assert abs(alt - inflated) > 1e-3, d
 
     def test_observer_look(self):
         """Test getting the observer look angles."""


### PR DESCRIPTION
`Orbital.get_lonlatalt` converts the propagated position to geodetic coordinates on the WGS84 ellipsoid, but it takes the position from `get_position(normalize=True)`, which divides kilometers by `XKMPER` = 6378.135 km, the WGS72 equatorial radius SGP4 propagates with (Hoots and Roehrich, Spacetrack Report No. 3, 1980). The geodetic iteration then runs with the WGS84 flattening, and the altitude is scaled back with `A` = 6378.137 km, the WGS84 equatorial radius (NIMA TR8350.2). Dividing by one radius and multiplying by the other inflates every altitude by `A / XKMPER - 1`: about 2.1 m for the ISS and about 13 m at geostationary altitude. Longitude and latitude are unaffected, since they depend only on direction.

The conversion now scales the kilometer position by `A`, so the whole geodetic step is on WGS84. SGP4 itself still runs with the WGS72 constants the elements are generated with, as the propagator's reference implementation recommends (Vallado, Crawford, Hujsak and Kelso, "Revisiting Spacetrack Report #3", AIAA 2006-6753).

The existing `test_sublonlat` expected altitude moves from 392.01953 km to 392.01741 km, and its altitude tolerance tightens to 1 mm. A new test converts the same positions to geodetic coordinates independently in kilometers on WGS84 and checks the altitude to a nanometre across an orbit, and checks that the previously inflated value no longer matches.
